### PR TITLE
Update motile_toolbox version to v0.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,8 @@ dependencies =[
 [project.optional-dependencies]
 testing =["napari", "pyqt5", "pytest", "pytest-cov", "pytest-qt"]
 docs = ["myst-parser", "sphinx", "sphinx-autoapi", "sphinx_rtd_theme", "sphinxcontrib-video"]
+dev = ["ruff", "pre-commit"]
+all = ["motile-tracker[testing,docs,dev]"]
 
 [project.entry-points."napari.manifest"]
 motile-tracker = "motile_tracker:napari.yaml"
@@ -59,6 +61,7 @@ motile-tracker = "motile_tracker:napari.yaml"
 line-length = 88
 target-version = "py310"
 fix = true
+src = ["src"]
 
 [tool.ruff.lint]
 select = [
@@ -74,7 +77,6 @@ select = [
     "PIE", # flake8-pie
     "SIM", # flake8-simplify
 ]
-
 ignore = [
     "UP006", "UP007", # type annotation. As using magicgui require runtime type annotation then we disable this.
     "ISC001", # implicit string concatenation
@@ -84,6 +86,7 @@ ignore = [
 unfixable = [
   "B905", # currently adds strict=False to zips. Should add strict=True (manually)
 ]
+
 
 [tool.ruff.lint.per-file-ignores]
 "scripts/*.py" = ["F"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies =[
     "qtpy",
     "scikit-image",
     "motile >= 0.3",
-    "motile_toolbox == 0.3.5",
+    "motile_toolbox == 0.4.0",
     "pydantic",
     "tifffile[all]",
     "fonticon-fontawesome6",

--- a/src/motile_tracker/data_model/tracks.py
+++ b/src/motile_tracker/data_model/tracks.py
@@ -230,7 +230,6 @@ class Tracks:
         if seg_ids is not None and self.segmentation is not None:
             self.set_seg_ids(nodes, seg_ids)
             computed_attrs = self._compute_node_attrs(seg_ids, times)
-            print(computed_attrs)
             if positions is None:
                 final_pos = np.array(computed_attrs[NodeAttr.POS.value])
             else:

--- a/src/motile_tracker/data_model/tracks.py
+++ b/src/motile_tracker/data_model/tracks.py
@@ -408,8 +408,6 @@ class Tracks:
         for pix, val in zip(pixels, values, strict=False):
             if val is None:
                 raise ValueError("Cannot set pixels to None value")
-            if len(pix) == self.ndim:
-                pix = (pix[0], *pix[1:])
             self.segmentation[pix] = val
 
     def update_segmentations(

--- a/src/motile_tracker/data_model/tracks.py
+++ b/src/motile_tracker/data_model/tracks.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 AttrValue: TypeAlias = Any
-Node: TypeAlias = Any
+Node: TypeAlias = int
 Edge: TypeAlias = tuple[Node, Node]
 AttrValues: TypeAlias = Sequence[AttrValue]
 Attrs: TypeAlias = Mapping[str, AttrValues]
@@ -230,6 +230,7 @@ class Tracks:
         if seg_ids is not None and self.segmentation is not None:
             self.set_seg_ids(nodes, seg_ids)
             computed_attrs = self._compute_node_attrs(seg_ids, times)
+            print(computed_attrs)
             if positions is None:
                 final_pos = np.array(computed_attrs[NodeAttr.POS.value])
             else:
@@ -385,10 +386,9 @@ class Tracks:
                 pix_list.append((np.array([], dtype=np.uint64),) * self.ndim)
             else:
                 time = self.get_time(node)
-                loc_pixels = np.nonzero(self.segmentation[time][0] == seg_id)
+                loc_pixels = np.nonzero(self.segmentation[time] == seg_id)
                 time_array = np.ones_like(loc_pixels[0]) * time
-                hypo_array = np.zeros_like(loc_pixels[0])
-                pix_list.append((time_array, hypo_array, *loc_pixels))
+                pix_list.append((time_array, *loc_pixels))
         return pix_list
 
     def set_pixels(
@@ -409,8 +409,7 @@ class Tracks:
             if val is None:
                 raise ValueError("Cannot set pixels to None value")
             if len(pix) == self.ndim:
-                # add dummy hypothesis dimension for now
-                pix = (pix[0], np.zeros_like(pix[0]), *pix[1:])
+                pix = (pix[0], *pix[1:])
             self.segmentation[pix] = val
 
     def update_segmentations(
@@ -637,7 +636,7 @@ class Tracks:
         scale: list[float] | None,
         provided_ndim: int | None,
     ):
-        seg_ndim = seg.ndim - 1 if seg is not None else None  # remove hypothesis dim
+        seg_ndim = seg.ndim if seg is not None else None
         scale_ndim = len(scale) if scale is not None else None
         ndims = [seg_ndim, scale_ndim, provided_ndim]
         ndims = [d for d in ndims if d is not None]
@@ -754,7 +753,7 @@ class Tracks:
                 area = None
                 pos = None
             else:
-                seg = self.segmentation[time][0] == seg_id
+                seg = self.segmentation[time] == seg_id
                 pos_scale = self.scale[1:] if self.scale is not None else None
                 area = np.sum(seg)
                 if pos_scale is not None:
@@ -803,8 +802,8 @@ class Tracks:
                 source_time = self.get_time(source)
                 target_time = self.get_time(target)
 
-                source_arr = self.segmentation[source_time][0] == source_seg
-                target_arr = self.segmentation[target_time][0] == target_seg
+                source_arr = self.segmentation[source_time] == source_seg
+                target_arr = self.segmentation[target_time] == target_seg
 
                 iou_list = _compute_ious(
                     source_arr, target_arr

--- a/src/motile_tracker/data_model/tracks_controller.py
+++ b/src/motile_tracker/data_model/tracks_controller.py
@@ -537,11 +537,11 @@ class TracksController:
         Returns:
             list[Node]: A list of new node ids.
         """
-        ids = [str(self.node_id_counter + i) for i in range(n)]
+        ids = [self.node_id_counter + i for i in range(n)]
         self.node_id_counter += n
         for idx, _id in enumerate(ids):
             while self.tracks.graph.has_node(_id):
                 self.node_id_counter += 1
-                _id = str(self.node_id_counter)
+                _id = self.node_id_counter
             ids[idx] = _id
         return ids

--- a/src/motile_tracker/data_views/views/layers/track_labels.py
+++ b/src/motile_tracker/data_views/views/layers/track_labels.py
@@ -205,7 +205,7 @@ class TrackLabels(napari.layers.Labels):
     def _refresh(self):
         """Refresh the data in the labels layer"""
 
-        self.data = self.tracks_viewer.tracks.segmentation[:, 0]
+        self.data = self.tracks_viewer.tracks.segmentation
         self.node_properties = self._get_node_properties()
 
         self.colormap = DirectLabelColormap(

--- a/src/motile_tracker/data_views/views/layers/tracks_layer_group.py
+++ b/src/motile_tracker/data_views/views/layers/tracks_layer_group.py
@@ -38,7 +38,7 @@ class TracksLayerGroup:
         if self.tracks is not None and self.tracks.segmentation is not None:
             self.seg_layer = TrackLabels(
                 viewer=self.viewer,
-                data=self.tracks.segmentation[:, 0],
+                data=self.tracks.segmentation,
                 name=self.name + "_seg",
                 opacity=0.9,
                 scale=self.tracks.scale,

--- a/src/motile_tracker/data_views/views_coordinator/tracks_viewer.py
+++ b/src/motile_tracker/data_views/views_coordinator/tracks_viewer.py
@@ -7,13 +7,12 @@ import numpy as np
 from motile_toolbox.candidate_graph.graph_attributes import NodeAttr
 from psygnal import Signal
 
-from motile_tracker.data_model import NodeType, SolutionTracks, Tracks
+from motile_tracker.data_model import NodeType, Tracks
 from motile_tracker.data_model.tracks_controller import TracksController
 from motile_tracker.data_views.views.layers.tracks_layer_group import TracksLayerGroup
 from motile_tracker.data_views.views.tree_view.tree_widget_utils import (
     extract_lineage_tree,
 )
-from motile_tracker.utils.relabel_segmentation import relabel_segmentation
 
 from .node_selection_list import NodeSelectionList
 from .tracks_list import TracksList
@@ -200,19 +199,6 @@ class TracksViewer:
         self.set_napari_view()
         visible = self.filter_visible_nodes()
         self.tracking_layers.update_visible(visible)
-
-    def view_external_tracks(self, tracks: SolutionTracks, name: str) -> None:
-        """View tracks created externally. Assigns tracklet ids, adds a hypothesis
-        dimension to the segmentation, and relabels the segmentation based on the
-        assigned track ids. Then calls update_tracks.
-
-        Args:
-            tracks (Tracks): A tracks object to view, created externally from the tracker
-            name (str): The name to display in napari layers
-        """
-        # tracks.segmentation = np.expand_dims(tracks.segmentation, axis=1)
-        tracks.segmentation = relabel_segmentation(tracks.graph, tracks.segmentation)
-        self.update_tracks(tracks, name)
 
     def set_napari_view(self) -> None:
         """Adjust the current_step of the viewer to jump to the last item of the selected_nodes list"""

--- a/src/motile_tracker/motile/backend/motile_run.py
+++ b/src/motile_tracker/motile/backend/motile_run.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 from motile_toolbox.candidate_graph.graph_attributes import NodeAttr
+
 from motile_tracker.data_model import SolutionTracks
 
 from .solver_params import SolverParams

--- a/src/motile_tracker/motile/backend/solve.py
+++ b/src/motile_tracker/motile/backend/solve.py
@@ -12,8 +12,8 @@ from motile.costs import Appear, EdgeDistance, EdgeSelection, Split
 from motile_toolbox.candidate_graph import (
     EdgeAttr,
     NodeAttr,
-    get_candidate_graph,
-    get_candidate_graph_from_points_list,
+    compute_graph_from_points_list,
+    compute_graph_from_seg,
     graph_to_nx,
 )
 
@@ -52,11 +52,11 @@ def solve(
             motile_toolbox for exact implementation details.
     """
     if input_data.ndim == 2:
-        cand_graph = get_candidate_graph_from_points_list(
+        cand_graph = compute_graph_from_points_list(
             input_data, solver_params.max_edge_distance, scale=scale
         )
     else:
-        cand_graph, _ = get_candidate_graph(
+        cand_graph = compute_graph_from_seg(
             input_data,
             solver_params.max_edge_distance,
             iou=solver_params.iou_cost is not None,

--- a/src/motile_tracker/motile/menus/motile_widget.py
+++ b/src/motile_tracker/motile/menus/motile_widget.py
@@ -5,9 +5,6 @@ import logging
 import networkx as nx
 import numpy as np
 from motile_toolbox.candidate_graph import NodeAttr
-from motile_tracker.data_model import SolutionTracks
-from motile_tracker.data_views.views_coordinator.tracks_viewer import TracksViewer
-from motile_tracker.motile.backend import MotileRun, solve
 from napari import Viewer
 from napari.utils.notifications import show_warning
 from psygnal import Signal
@@ -17,6 +14,10 @@ from qtpy.QtWidgets import (
     QWidget,
 )
 from superqt.utils import thread_worker
+
+from motile_tracker.data_model import SolutionTracks
+from motile_tracker.data_views.views_coordinator.tracks_viewer import TracksViewer
+from motile_tracker.motile.backend import MotileRun, solve
 
 from .run_editor import RunEditor
 from .run_viewer import RunViewer

--- a/src/motile_tracker/motile/menus/params_editor.py
+++ b/src/motile_tracker/motile/menus/params_editor.py
@@ -1,7 +1,6 @@
 from functools import partial
 from types import NoneType
 
-from motile_tracker.motile.backend import SolverParams
 from qtpy.QtCore import Signal
 from qtpy.QtWidgets import (
     QCheckBox,
@@ -11,6 +10,8 @@ from qtpy.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
+
+from motile_tracker.motile.backend import SolverParams
 
 from .param_values import EditableParamValue
 

--- a/src/motile_tracker/motile/menus/params_viewer.py
+++ b/src/motile_tracker/motile/menus/params_viewer.py
@@ -1,4 +1,3 @@
-from motile_tracker.motile.backend import SolverParams
 from qtpy.QtCore import Signal
 from qtpy.QtWidgets import (
     QGroupBox,
@@ -7,6 +6,8 @@ from qtpy.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
+
+from motile_tracker.motile.backend import SolverParams
 
 from .param_values import StaticParamValue
 

--- a/src/motile_tracker/motile/menus/run_editor.py
+++ b/src/motile_tracker/motile/menus/run_editor.py
@@ -9,7 +9,6 @@ import napari.layers
 import networkx as nx
 import numpy as np
 from motile_toolbox.utils.relabel_segmentation import ensure_unique_labels
-from motile_tracker.motile.backend import MotileRun
 from qtpy.QtCore import Signal
 from qtpy.QtWidgets import (
     QComboBox,
@@ -22,6 +21,8 @@ from qtpy.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
+
+from motile_tracker.motile.backend import MotileRun
 
 from .params_editor import SolverParamsEditor
 

--- a/src/motile_tracker/motile/menus/run_editor.py
+++ b/src/motile_tracker/motile/menus/run_editor.py
@@ -7,6 +7,8 @@ from warnings import warn
 
 import napari.layers
 import networkx as nx
+import numpy as np
+from motile_toolbox.utils.relabel_segmentation import ensure_unique_labels
 from motile_tracker.motile.backend import MotileRun
 from qtpy.QtCore import Signal
 from qtpy.QtWidgets import (
@@ -147,6 +149,29 @@ class RunEditor(QGroupBox):
         run_widget.setLayout(run_layout)
         return run_widget
 
+    @staticmethod
+    def _has_duplicate_ids(segmentation: np.ndarray) -> bool:
+        """Checks if the segmentation has duplicate label ids across time. For efficiency,
+        only checks between the first and second time frames.
+
+        Args:
+            segmentation (np.ndarray): (t, [z], y, x)
+
+        Returns:
+            bool: True if there are duplicate labels between the first two frames, and
+                False otherwise.
+        """
+        if segmentation.shape[0] >= 2:
+            first_frame_ids = set(np.unique(segmentation[0]).tolist())
+            first_frame_ids.remove(0)
+            print(first_frame_ids)
+            second_frame_ids = set(np.unique(segmentation[1]).tolist())
+            second_frame_ids.remove(0)
+            print(second_frame_ids)
+            return not first_frame_ids.isdisjoint(second_frame_ids)
+        else:
+            return False
+
     def get_run(self) -> MotileRun | None:
         """Construct a motile run from the current state of the run editor
         widget.
@@ -171,6 +196,9 @@ class RunEditor(QGroupBox):
                 raise ValueError(
                     "Expected segmentation to be at least 3D, found %d", ndim
                 )
+            if self._has_duplicate_ids(input_seg):
+                input_seg = ensure_unique_labels(input_seg)
+
             input_points = None
         elif isinstance(input_layer, napari.layers.Points):
             input_seg = None

--- a/src/motile_tracker/motile/menus/run_viewer.py
+++ b/src/motile_tracker/motile/menus/run_viewer.py
@@ -6,7 +6,6 @@ from warnings import warn
 
 import pyqtgraph as pg
 from fonticon_fa6 import FA6S
-from motile_tracker.motile.backend import MotileRun
 from qtpy.QtCore import Signal
 from qtpy.QtWidgets import (
     QFileDialog,
@@ -19,6 +18,8 @@ from qtpy.QtWidgets import (
 )
 from superqt import QCollapsible, ensure_main_thread
 from superqt.fonticon import icon as qticon
+
+from motile_tracker.motile.backend import MotileRun
 
 from .params_viewer import SolverParamsViewer
 

--- a/src/motile_tracker/utils/load_tracks.py
+++ b/src/motile_tracker/utils/load_tracks.py
@@ -2,6 +2,7 @@ from csv import DictReader
 
 import networkx as nx
 import numpy as np
+
 from motile_tracker.data_model import SolutionTracks
 
 

--- a/src/motile_tracker/utils/load_tracks.py
+++ b/src/motile_tracker/utils/load_tracks.py
@@ -44,7 +44,7 @@ def tracks_from_csv(
                     graph.add_edge(parent_id, _id)
     tracks = SolutionTracks(
         graph=graph,
-        segmentation=np.expand_dims(segmentation, axis=1),
+        segmentation=segmentation,
         pos_attr="pos",
         time_attr="time",
     )

--- a/src/motile_tracker/utils/relabel_segmentation.py
+++ b/src/motile_tracker/utils/relabel_segmentation.py
@@ -21,7 +21,7 @@ def relabel_segmentation(
         np.ndarray: Relabeled segmentation array where nodes in same track share same
             id with shape (t,[z],y,x)
     """
-    tracked_masks = np.zeros_like(segmentation, shape=segmentation.shape)
+    tracked_masks = np.zeros_like(segmentation)
     for node, _data in solution_nx_graph.nodes(data=True):
         time_frame = solution_nx_graph.nodes[node][NodeAttr.TIME.value]
         previous_seg_id = solution_nx_graph.nodes[node][NodeAttr.SEG_ID.value]

--- a/src/motile_tracker/utils/relabel_segmentation.py
+++ b/src/motile_tracker/utils/relabel_segmentation.py
@@ -13,25 +13,21 @@ def relabel_segmentation(
     Args:
         solution_nx_graph (nx.DiGraph): Networkx graph with the solution to use
             for relabeling. Nodes not in graph will be removed from seg. Original
-            segmentation ids and hypothesis ids have to be stored in the graph so we
-            can map them back. Assumes tracket ids have already been assigned.
-        segmentation (np.ndarray): Original (potentially multi-hypothesis)
-            segmentation with dimensions (t,h,[z],y,x), where h is 1 for single
-            input segmentation.
+            segmentation ids have to be stored in the graph so we
+            can map them back. Assumes tracklet ids have already been assigned.
+        segmentation (np.ndarray): Original segmentation with dimensions (t,z],y,x)
 
     Returns:
         np.ndarray: Relabeled segmentation array where nodes in same track share same
-            id with shape (t,1,[z],y,x)
+            id with shape (t,[z],y,x)
     """
-    output_shape = (segmentation.shape[0], 1, *segmentation.shape[2:])
-    tracked_masks = np.zeros_like(segmentation, shape=output_shape)
+    tracked_masks = np.zeros_like(segmentation, shape=segmentation.shape)
     for node, _data in solution_nx_graph.nodes(data=True):
         time_frame = solution_nx_graph.nodes[node][NodeAttr.TIME.value]
         previous_seg_id = solution_nx_graph.nodes[node][NodeAttr.SEG_ID.value]
         assert previous_seg_id != 0
         tracklet_id = solution_nx_graph.nodes[node][NodeAttr.TRACK_ID.value]
-        hypothesis_id = solution_nx_graph.nodes[node].get(NodeAttr.SEG_HYPO.value, 0)
-        previous_seg_mask = segmentation[time_frame, hypothesis_id] == previous_seg_id
-        tracked_masks[time_frame, 0][previous_seg_mask] = tracklet_id
+        previous_seg_mask = segmentation[time_frame] == previous_seg_id
+        tracked_masks[time_frame][previous_seg_mask] = tracklet_id
         solution_nx_graph.nodes[node][NodeAttr.SEG_ID.value] = tracklet_id
     return tracked_masks

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,59 +15,19 @@ def segmentation_2d():
     segmentation[0][rr, cc] = 1
 
     # make frame with two cells
-    # first cell centered at (20, 80) with label 1
-    # second cell centered at (60, 45) with label 2
+    # first cell centered at (20, 80) with label 2
+    # second cell centered at (60, 45) with label 3
     rr, cc = disk(center=(20, 80), radius=10, shape=frame_shape)
     segmentation[1][rr, cc] = 2
     rr, cc = disk(center=(60, 45), radius=15, shape=frame_shape)
     segmentation[1][rr, cc] = 3
 
     # continue track 3 with squares from 0 to 4 in x and y with label 3
-    segmentation[2, 0:4, 0:4] = 3
-    segmentation[4, 0:4, 0:4] = 3
+    segmentation[2, 0:4, 0:4] = 4
+    segmentation[4, 0:4, 0:4] = 5
 
     # unconnected node
-    segmentation[4, 96:100, 96:100] = 5
-    print(np.sum(segmentation == 5))
-
-    return np.expand_dims(segmentation, 1)
-
-
-@pytest.fixture
-def multi_hypothesis_segmentation_2d():
-    """
-    Creates a multi-hypothesis version of the `segmentation_2d` fixture defined above.
-
-    """
-    frame_shape = (100, 100)
-    total_shape = (
-        2,
-        2,
-        *frame_shape,
-    )  # 2 time points, 2 hypotheses layers, H, W
-    segmentation = np.zeros(total_shape, dtype="int32")
-    # make frame with one cell in center with label 1 (hypo 1)
-    rr0, cc0 = disk(center=(50, 50), radius=20, shape=frame_shape)
-    # make frame with one cell at (45, 45) with label 1 (hypo 2)
-    rr1, cc1 = disk(center=(45, 45), radius=15, shape=frame_shape)
-
-    segmentation[0, 0][rr0, cc0] = 1
-    segmentation[0, 1][rr1, cc1] = 1
-
-    # make frame with two cells
-    # first cell centered at (20, 80) with label 1
-    rr0, cc0 = disk(center=(20, 80), radius=10, shape=frame_shape)
-    rr1, cc1 = disk(center=(15, 75), radius=15, shape=frame_shape)
-
-    segmentation[1, 0][rr0, cc0] = 1
-    segmentation[1, 1][rr1, cc1] = 1
-
-    # second cell centered at (60, 45) with label 2
-    rr0, cc0 = disk(center=(60, 45), radius=15, shape=frame_shape)
-    rr1, cc1 = disk(center=(55, 40), radius=20, shape=frame_shape)
-
-    segmentation[1, 0][rr0, cc0] = 2
-    segmentation[1, 1][rr1, cc1] = 2
+    segmentation[4, 96:100, 96:100] = 6
 
     return segmentation
 
@@ -77,7 +37,7 @@ def graph_2d():
     graph = nx.DiGraph()
     nodes = [
         (
-            "0_1",
+            1,
             {
                 NodeAttr.POS.value: [50, 50],
                 NodeAttr.TIME.value: 0,
@@ -87,7 +47,7 @@ def graph_2d():
             },
         ),
         (
-            "1_2",
+            2,
             {
                 NodeAttr.POS.value: [20, 80],
                 NodeAttr.TIME.value: 1,
@@ -97,7 +57,7 @@ def graph_2d():
             },
         ),
         (
-            "1_3",
+            3,
             {
                 NodeAttr.POS.value: [60, 45],
                 NodeAttr.TIME.value: 1,
@@ -107,171 +67,49 @@ def graph_2d():
             },
         ),
         (
-            2,
+            4,
             {
                 NodeAttr.POS.value: [1.5, 1.5],
                 NodeAttr.TIME.value: 2,
-                NodeAttr.SEG_ID.value: 3,
+                NodeAttr.SEG_ID.value: 4,
                 NodeAttr.AREA.value: 16,
                 NodeAttr.TRACK_ID.value: 3,
             },
         ),
         (
-            4,
+            5,
             {
                 NodeAttr.POS.value: [1.5, 1.5],
                 NodeAttr.TIME.value: 4,
-                NodeAttr.SEG_ID.value: 3,
+                NodeAttr.SEG_ID.value: 5,
                 NodeAttr.AREA.value: 16,
                 NodeAttr.TRACK_ID.value: 3,
             },
         ),
         # unconnected node
         (
-            5,
+            6,
             {
                 NodeAttr.POS.value: [97.5, 97.5],
                 NodeAttr.TIME.value: 4,
-                NodeAttr.SEG_ID.value: 5,
+                NodeAttr.SEG_ID.value: 6,
                 NodeAttr.AREA.value: 16,
                 NodeAttr.TRACK_ID.value: 5,
             },
         ),
     ]
     edges = [
+        (1, 2, {EdgeAttr.IOU.value: 0.0}),
+        (1, 3, {EdgeAttr.IOU.value: 0.395}),
         (
-            "0_1",
-            "1_2",
-            {EdgeAttr.IOU.value: 0.0},
-        ),
-        (
-            "0_1",
-            "1_3",
-            {EdgeAttr.IOU.value: 0.395},
-        ),
-        (
-            "1_3",
-            2,
-            {EdgeAttr.IOU.value: 0.0},
-        ),
-        (
-            2,
+            3,
             4,
+            {EdgeAttr.IOU.value: 0.0},
+        ),
+        (
+            4,
+            5,
             {EdgeAttr.IOU.value: 1.0},
-        ),
-    ]
-    graph.add_nodes_from(nodes)
-    graph.add_edges_from(edges)
-
-    return graph
-
-
-@pytest.fixture
-def multi_hypothesis_graph_2d():
-    graph = nx.DiGraph()
-    nodes = [
-        (
-            "0_0_1",
-            {
-                NodeAttr.POS.value: [50, 50],
-                NodeAttr.TIME.value: 0,
-                NodeAttr.SEG_HYPO.value: 0,
-                NodeAttr.SEG_ID.value: 1,
-                NodeAttr.AREA.value: 1245,
-            },
-        ),
-        (
-            "0_1_1",
-            {
-                NodeAttr.POS.value: [45, 45],
-                NodeAttr.TIME.value: 0,
-                NodeAttr.SEG_HYPO.value: 1,
-                NodeAttr.SEG_ID.value: 1,
-                NodeAttr.AREA.value: 697,
-            },
-        ),
-        (
-            "1_0_1",
-            {
-                NodeAttr.POS.value: [20, 80],
-                NodeAttr.TIME.value: 1,
-                NodeAttr.SEG_HYPO.value: 0,
-                NodeAttr.SEG_ID.value: 1,
-                NodeAttr.AREA.value: 305,
-            },
-        ),
-        (
-            "1_1_1",
-            {
-                NodeAttr.POS.value: [15, 75],
-                NodeAttr.TIME.value: 1,
-                NodeAttr.SEG_HYPO.value: 1,
-                NodeAttr.SEG_ID.value: 1,
-                NodeAttr.AREA.value: 697,
-            },
-        ),
-        (
-            "1_0_2",
-            {
-                NodeAttr.POS.value: [60, 45],
-                NodeAttr.TIME.value: 1,
-                NodeAttr.SEG_HYPO.value: 0,
-                NodeAttr.SEG_ID.value: 2,
-                NodeAttr.AREA.value: 697,
-                NodeAttr.AREA.value: 1245,
-            },
-        ),
-        (
-            "1_1_2",
-            {
-                NodeAttr.POS.value: [55, 40],
-                NodeAttr.TIME.value: 1,
-                NodeAttr.SEG_HYPO.value: 1,
-                NodeAttr.SEG_ID.value: 2,
-            },
-        ),
-    ]
-
-    edges = [
-        (
-            "0_0_1",
-            "1_0_1",
-            {EdgeAttr.IOU.value: 0.0},
-        ),
-        (
-            "0_0_1",
-            "1_1_1",
-            {EdgeAttr.IOU.value: 0.0},
-        ),
-        (
-            "0_0_1",
-            "1_0_2",
-            {EdgeAttr.IOU.value: 0.3931},
-        ),
-        (
-            "0_0_1",
-            "1_1_2",
-            {EdgeAttr.IOU.value: 0.4768},
-        ),
-        (
-            "0_1_1",
-            "1_0_1",
-            {EdgeAttr.IOU.value: 0.0},
-        ),
-        (
-            "0_1_1",
-            "1_1_1",
-            {EdgeAttr.IOU.value: 0.0},
-        ),
-        (
-            "0_1_1",
-            "1_0_2",
-            {EdgeAttr.IOU.value: 0.2402},
-        ),
-        (
-            "0_1_1",
-            "1_1_2",
-            {EdgeAttr.IOU.value: 0.3931},
         ),
     ]
     graph.add_nodes_from(nodes)
@@ -297,44 +135,12 @@ def segmentation_3d():
     segmentation[0][mask] = 1
 
     # make frame with two cells
-    # first cell centered at (20, 50, 80) with label 1
-    # second cell centered at (60, 50, 45) with label 2
+    # first cell centered at (20, 50, 80) with label 2
+    # second cell centered at (60, 50, 45) with label 3
     mask = sphere(center=(20, 50, 80), radius=10, shape=frame_shape)
-    segmentation[1][mask] = 1
-    mask = sphere(center=(60, 50, 45), radius=15, shape=frame_shape)
     segmentation[1][mask] = 2
-
-    return np.expand_dims(segmentation, 1)
-
-
-@pytest.fixture
-def multi_hypothesis_segmentation_3d():
-    """
-    Creates a multi-hypothesis version of the `segmentation_3d` fixture defined above.
-
-    """
-    frame_shape = (100, 100, 100)
-    total_shape = (2, 2, *frame_shape)  # 2 time points, 2 hypotheses
-    segmentation = np.zeros(total_shape, dtype="int32")
-    # make first frame with one cell in center with label 1
-    mask = sphere(center=(50, 50, 50), radius=20, shape=frame_shape)
-    segmentation[0, 0][mask] = 1
-    mask = sphere(center=(45, 50, 55), radius=20, shape=frame_shape)
-    segmentation[0, 1][mask] = 1
-
-    # make second frame, first hypothesis with two cells
-    # first cell centered at (20, 50, 80) with label 1
-    # second cell centered at (60, 50, 45) with label 2
-    mask = sphere(center=(20, 50, 80), radius=10, shape=frame_shape)
-    segmentation[1, 0][mask] = 1
     mask = sphere(center=(60, 50, 45), radius=15, shape=frame_shape)
-    segmentation[1, 0][mask] = 2
-
-    # make second frame, second hypothesis with one cell
-    # first cell centered at (15, 50, 70) with label 1
-    # second cell centered at (55, 55, 45) with label 2
-    mask = sphere(center=(15, 50, 70), radius=10, shape=frame_shape)
-    segmentation[1, 1][mask] = 1
+    segmentation[1][mask] = 3
 
     return segmentation
 
@@ -344,7 +150,7 @@ def graph_3d():
     graph = nx.DiGraph()
     nodes = [
         (
-            "0_1",
+            1,
             {
                 NodeAttr.POS.value: [50, 50, 50],
                 NodeAttr.TIME.value: 0,
@@ -352,88 +158,25 @@ def graph_3d():
             },
         ),
         (
-            "1_1",
+            2,
             {
                 NodeAttr.POS.value: [20, 50, 80],
-                NodeAttr.TIME.value: 1,
-                NodeAttr.SEG_ID.value: 1,
-            },
-        ),
-        (
-            "1_2",
-            {
-                NodeAttr.POS.value: [60, 50, 45],
                 NodeAttr.TIME.value: 1,
                 NodeAttr.SEG_ID.value: 2,
             },
         ),
-    ]
-    edges = [
-        ("0_1", "1_1"),
-        ("0_1", "1_2"),
-    ]
-    graph.add_nodes_from(nodes)
-    graph.add_edges_from(edges)
-    return graph
-
-
-@pytest.fixture
-def multi_hypothesis_graph_3d():
-    graph = nx.DiGraph()
-    nodes = [
         (
-            "0_0_1",
-            {
-                NodeAttr.POS.value: [50, 50, 50],
-                NodeAttr.TIME.value: 0,
-                NodeAttr.SEG_HYPO.value: 0,
-                NodeAttr.SEG_ID.value: 1,
-            },
-        ),
-        (
-            "0_1_1",
-            {
-                NodeAttr.POS.value: [45, 50, 55],
-                NodeAttr.TIME.value: 1,
-                NodeAttr.SEG_HYPO.value: 1,
-                NodeAttr.SEG_ID.value: 1,
-            },
-        ),
-        (
-            "1_0_1",
-            {
-                NodeAttr.POS.value: [20, 50, 80],
-                NodeAttr.TIME.value: 1,
-                NodeAttr.SEG_HYPO.value: 0,
-                NodeAttr.SEG_ID.value: 1,
-            },
-        ),
-        (
-            "1_0_2",
+            3,
             {
                 NodeAttr.POS.value: [60, 50, 45],
                 NodeAttr.TIME.value: 1,
-                NodeAttr.SEG_HYPO.value: 0,
-                NodeAttr.SEG_ID.value: 2,
-            },
-        ),
-        (
-            "1_1_1",
-            {
-                NodeAttr.POS.value: [15, 50, 70],
-                NodeAttr.TIME.value: 1,
-                NodeAttr.SEG_HYPO.value: 1,
-                NodeAttr.SEG_ID.value: 1,
+                NodeAttr.SEG_ID.value: 3,
             },
         ),
     ]
     edges = [
-        ("0_0_1", "1_0_1"),
-        ("0_0_1", "1_0_2"),
-        ("0_1_1", "1_0_1"),
-        ("0_1_1", "1_0_2"),
-        ("0_0_1", "1_1_1"),
-        ("0_1_1", "1_1_1"),
+        (1, 2),
+        (1, 3),
     ]
     graph.add_nodes_from(nodes)
     graph.add_edges_from(edges)

--- a/tests/data_model/test_action_history.py
+++ b/tests/data_model/test_action_history.py
@@ -1,4 +1,5 @@
 import networkx as nx
+
 from motile_tracker.data_model.action_history import ActionHistory
 from motile_tracker.data_model.actions import AddNodes
 from motile_tracker.data_model.tracks import Tracks

--- a/tests/data_model/test_actions.py
+++ b/tests/data_model/test_actions.py
@@ -2,13 +2,14 @@ import networkx as nx
 import numpy as np
 import pytest
 from motile_toolbox.candidate_graph.graph_attributes import EdgeAttr, NodeAttr
+from numpy.testing import assert_array_almost_equal
+
 from motile_tracker.data_model import Tracks
 from motile_tracker.data_model.actions import (
     AddEdges,
     AddNodes,
     UpdateNodeSegs,
 )
-from numpy.testing import assert_array_almost_equal
 
 
 def test_add_delete_nodes(segmentation_2d, graph_2d):

--- a/tests/data_model/test_actions.py
+++ b/tests/data_model/test_actions.py
@@ -32,12 +32,12 @@ def test_add_delete_nodes(segmentation_2d, graph_2d):
     pixels = [
         np.nonzero(segmentation_2d[time] == track_id)
         for time, track_id in zip(
-            attrs[NodeAttr.TIME.value], attrs[NodeAttr.TRACK_ID.value], strict=False
+            attrs[NodeAttr.TIME.value], attrs[NodeAttr.SEG_ID.value], strict=True
         )
     ]
     pixels = [
         (np.ones_like(pix[0]) * time, *pix)
-        for time, pix in zip(attrs[NodeAttr.TIME.value], pixels, strict=False)
+        for time, pix in zip(attrs[NodeAttr.TIME.value], pixels, strict=True)
     ]
     add_nodes = AddNodes(tracks, nodes, attributes=attrs, pixels=pixels)
 
@@ -72,17 +72,17 @@ def test_update_node_segs(segmentation_2d, graph_2d):
 
     # add a couple pixels to the first node
     new_seg = segmentation_2d.copy()
-    new_seg[0][0][0] = 1
-    nodes = ["0_1"]
+    new_seg[0][0] = 1
+    nodes = [1]
 
     pixels = [np.nonzero(segmentation_2d != new_seg)]
     action = UpdateNodeSegs(tracks, nodes, pixels=pixels, added=True)
 
     assert set(tracks.graph.nodes()) == set(graph_2d.nodes())
-    assert tracks.graph.nodes["0_1"][NodeAttr.AREA.value] == 1345
+    assert tracks.graph.nodes[1][NodeAttr.AREA.value] == 1345
     assert (
-        tracks.graph.nodes["0_1"][NodeAttr.POS.value]
-        != graph_2d.nodes["0_1"][NodeAttr.POS.value]
+        tracks.graph.nodes[1][NodeAttr.POS.value]
+        != graph_2d.nodes[1][NodeAttr.POS.value]
     )
     assert_array_almost_equal(tracks.segmentation, new_seg)
 
@@ -95,10 +95,10 @@ def test_update_node_segs(segmentation_2d, graph_2d):
     inverse.inverse()
 
     assert set(tracks.graph.nodes()) == set(graph_2d.nodes())
-    assert tracks.graph.nodes["0_1"][NodeAttr.AREA.value] == 1345
+    assert tracks.graph.nodes[1][NodeAttr.AREA.value] == 1345
     assert (
-        tracks.graph.nodes["0_1"][NodeAttr.POS.value]
-        != graph_2d.nodes["0_1"][NodeAttr.POS.value]
+        tracks.graph.nodes[1][NodeAttr.POS.value]
+        != graph_2d.nodes[1][NodeAttr.POS.value]
     )
     assert_array_almost_equal(tracks.segmentation, new_seg)
 
@@ -107,7 +107,7 @@ def test_add_delete_edges(graph_2d, segmentation_2d):
     node_graph = nx.create_empty_copy(graph_2d, with_data=True)
     tracks = Tracks(node_graph, segmentation_2d)
 
-    edges = [["0_1", "1_2"], ["0_1", "1_3"], ["1_3", 2], [2, 4]]
+    edges = [[1, 2], [1, 3], [3, 4], [4, 5]]
 
     action = AddEdges(tracks, edges)
     # TODO: What if adding an edge that already exists?

--- a/tests/data_model/test_tracks.py
+++ b/tests/data_model/test_tracks.py
@@ -2,6 +2,7 @@ import networkx as nx
 import numpy as np
 import pytest
 from motile_toolbox.candidate_graph import NodeAttr
+
 from motile_tracker.data_model import Tracks
 
 

--- a/tests/data_model/test_tracks_controller.py
+++ b/tests/data_model/test_tracks_controller.py
@@ -1,5 +1,6 @@
 import numpy as np
 from motile_toolbox.candidate_graph.graph_attributes import NodeAttr
+
 from motile_tracker.data_model.solution_tracks import SolutionTracks
 from motile_tracker.data_model.tracks_controller import TracksController
 

--- a/tests/data_model/test_tracks_controller.py
+++ b/tests/data_model/test_tracks_controller.py
@@ -75,7 +75,7 @@ def test__add_nodes_with_seg(graph_2d, segmentation_2d):
     new_seg = segmentation_2d.copy()
     time = 0
     seg_id = 6
-    new_seg[time : time + 2, 0, 90:100, 0:4] = seg_id
+    new_seg[time : time + 2, 90:100, 0:4] = seg_id
     expected_center = [94.5, 1.5]
     # start a new track
     attrs = {
@@ -110,7 +110,7 @@ def test__add_nodes_with_seg(graph_2d, segmentation_2d):
     # add nodes to end of existing track
     time = 2
     seg_id = 2
-    new_seg[time : time + 2, 0, 0:10, 0:4] = seg_id
+    new_seg[time : time + 2, 0:10, 0:4] = seg_id
     expected_center = [4.5, 1.5]
     # start a new track
     attrs = {
@@ -132,13 +132,13 @@ def test__add_nodes_with_seg(graph_2d, segmentation_2d):
     assert tracks.get_seg_id(node) == 2
     assert np.sum(tracks.segmentation != new_seg) == 0
 
-    assert tracks.graph.has_edge("1_2", node)
+    assert tracks.graph.has_edge(2, node)
     assert tracks.graph.has_edge(node, node_ids[1])
 
     # add node to middle of existing track
     time = 3
     seg_id = 3
-    new_seg[time, 0, 0:10, 0:4] = seg_id
+    new_seg[time, 0:10, 0:4] = seg_id
     expected_center = [4.5, 1.5]
     attrs = {
         NodeAttr.TIME.value: [time],
@@ -158,9 +158,9 @@ def test__add_nodes_with_seg(graph_2d, segmentation_2d):
     assert tracks.get_track_id(node) == 3
     assert np.sum(tracks.segmentation != new_seg) == 0
 
-    assert tracks.graph.has_edge(2, node)
-    assert tracks.graph.has_edge(node, 4)
-    assert not tracks.graph.has_edge(2, 4)
+    assert tracks.graph.has_edge(4, node)
+    assert tracks.graph.has_edge(node, 5)
+    assert not tracks.graph.has_edge(4, 5)
 
 
 def test__delete_nodes_no_seg(graph_2d):
@@ -214,8 +214,8 @@ def test__delete_nodes_with_seg(graph_2d, segmentation_2d):
     num_edges = tracks.graph.number_of_edges()
 
     # delete unconnected node
-    node = 5
-    track_id = 5
+    node = 6
+    track_id = 6
     time = 4
     action = controller._delete_nodes([node])
     assert not tracks.graph.has_node(node)
@@ -224,48 +224,48 @@ def test__delete_nodes_with_seg(graph_2d, segmentation_2d):
     action.inverse()
 
     # delete end node
-    node = 4
+    node = 5
     track_id = 3
     time = 4
     action = controller._delete_nodes([node])
     assert not tracks.graph.has_node(node)
     assert track_id not in np.unique(tracks.segmentation[time])
-    assert not tracks.graph.has_edge(3, node)
+    assert not tracks.graph.has_edge(4, node)
     action.inverse()
 
     # delete continuation node
-    node = 2
+    node = 4
     track_id = 3
     time = 2
     action = controller._delete_nodes([node])
     assert not tracks.graph.has_node(node)
     assert track_id not in np.unique(tracks.segmentation[time])
-    assert not tracks.graph.has_edge("1_3", node)
-    assert not tracks.graph.has_edge(node, 4)
-    assert tracks.graph.has_edge("1_3", 4)
-    assert tracks.get_track_id(4) == 3
+    assert not tracks.graph.has_edge(3, node)
+    assert not tracks.graph.has_edge(node, 5)
+    assert tracks.graph.has_edge(3, 5)
+    assert tracks.get_track_id(5) == 3
     action.inverse()
 
     # delete div parent
-    node = "0_1"
+    node = 1
     track_id = 1
     time = 0
     action = controller._delete_nodes([node])
     assert not tracks.graph.has_node(node)
     assert track_id not in np.unique(tracks.segmentation[time])
-    assert not tracks.graph.has_edge(node, "1_2")
-    assert not tracks.graph.has_edge(node, "1_3")
+    assert not tracks.graph.has_edge(node, 2)
+    assert not tracks.graph.has_edge(node, 3)
     action.inverse()
 
     # delete div child
-    node = "1_2"
+    node = 2
     track_id = 2
     time = 1
     action = controller._delete_nodes([node])
     assert not tracks.graph.has_node(node)
     assert track_id not in np.unique(tracks.segmentation[time])
-    assert tracks.get_track_id("1_3") == 1  # update track id for other child
-    assert tracks.get_track_id(4) == 1  # update track id for other child
+    assert tracks.get_track_id(3) == 1  # update track id for other child
+    assert tracks.get_track_id(5) == 1  # update track id for other child
 
 
 def test__add_remove_edges_no_seg(graph_2d):

--- a/tests/data_model/test_tracks_controller.py
+++ b/tests/data_model/test_tracks_controller.py
@@ -19,6 +19,7 @@ def test__add_nodes_no_seg(graph_2d):
     }
 
     action, node_ids = controller._add_nodes(attrs)
+    print(node_ids)
 
     node = node_ids[0]
     assert tracks.graph.has_node(node)
@@ -42,8 +43,8 @@ def test__add_nodes_no_seg(graph_2d):
     assert tracks.get_position(node1) == [1, 3]
     assert tracks.get_track_id(node1) == 2
     assert tracks.get_seg_id(node1) is None
-
-    assert tracks.graph.has_edge("1_2", node1)
+    print(tracks.graph.nodes[2])
+    assert tracks.graph.has_edge(2, node1)
     assert tracks.graph.has_edge(node1, node2)
 
     # add node to middle of existing track
@@ -60,9 +61,9 @@ def test__add_nodes_no_seg(graph_2d):
     assert tracks.get_track_id(node) == 3
     assert tracks.get_seg_id(node) is None
 
-    assert tracks.graph.has_edge(2, node)
-    assert tracks.graph.has_edge(node, 4)
-    assert not tracks.graph.has_edge(2, 4)
+    assert tracks.graph.has_edge(4, node)
+    assert tracks.graph.has_edge(node, 5)
+    assert not tracks.graph.has_edge(4, 5)
 
 
 def test__add_nodes_with_seg(graph_2d, segmentation_2d):
@@ -169,43 +170,42 @@ def test__delete_nodes_no_seg(graph_2d):
     num_edges = tracks.graph.number_of_edges()
 
     # delete unconnected node
-    node = 5
+    node = 6
     action = controller._delete_nodes([node])
     assert not tracks.graph.has_node(node)
     assert tracks.graph.number_of_edges() == num_edges
     action.inverse()
 
     # delete end node
+    node = 5
+    action = controller._delete_nodes([node])
+    assert not tracks.graph.has_node(node)
+    assert not tracks.graph.has_edge(4, node)
+    action.inverse()
+
+    # delete continuation node
     node = 4
     action = controller._delete_nodes([node])
     assert not tracks.graph.has_node(node)
     assert not tracks.graph.has_edge(3, node)
-    action.inverse()
-
-    # delete continuation node
-    node = 2
-    action = controller._delete_nodes([node])
-    assert not tracks.graph.has_node(node)
-    assert not tracks.graph.has_edge("1_3", node)
-    assert not tracks.graph.has_edge(node, 4)
-    assert tracks.graph.has_edge("1_3", 4)
-    assert tracks.get_track_id(4) == 3
+    assert not tracks.graph.has_edge(node, 5)
+    assert tracks.graph.has_edge(3, 5)
+    assert tracks.get_track_id(5) == 3
     action.inverse()
 
     # delete div parent
-    node = "0_1"
+    node = 1
     action = controller._delete_nodes([node])
     assert not tracks.graph.has_node(node)
-    assert not tracks.graph.has_edge(node, "1_2")
-    assert not tracks.graph.has_edge(node, "1_3")
+    assert not tracks.graph.has_edge(node, 2)
+    assert not tracks.graph.has_edge(node, 3)
     action.inverse()
 
     # delete div child
-    node = "1_2"
+    node = 3
     action = controller._delete_nodes([node])
     assert not tracks.graph.has_node(node)
-    assert tracks.get_track_id("1_3") == 1  # update track id for other child
-    assert tracks.get_track_id(4) == 1  # update track id for other child
+    assert tracks.get_track_id(2) == 1  # update track id for other child
 
 
 def test__delete_nodes_with_seg(graph_2d, segmentation_2d):
@@ -274,7 +274,7 @@ def test__add_remove_edges_no_seg(graph_2d):
     num_edges = tracks.graph.number_of_edges()
 
     # delete continuation edge
-    edge = ("1_3", 2)
+    edge = (3, 4)
     track_id = 3
     controller._delete_edges([edge])
     assert not tracks.graph.has_edge(*edge)
@@ -288,21 +288,19 @@ def test__add_remove_edges_no_seg(graph_2d):
     assert tracks.graph.number_of_edges() == num_edges
 
     # delete division edge
-    edge = ("0_1", "1_3")
+    edge = (1, 3)
     track_id = 3
     controller._delete_edges([edge])
     assert not tracks.graph.has_edge(*edge)
     assert tracks.get_track_id(edge[1]) == track_id  # dont relabel after removal
-    assert tracks.get_track_id("1_2") == 1  # but do relabel the sibling
+    assert tracks.get_track_id(2) == 1  # but do relabel the sibling
     assert tracks.graph.number_of_edges() == num_edges - 1
 
     # add back in division edge
-    edge = ("0_1", "1_3")
+    edge = (1, 3)
     track_id = 3
     controller._add_edges([edge])
     assert tracks.graph.has_edge(*edge)
     assert tracks.get_track_id(edge[1]) == track_id  # dont relabel after removal
-    assert (
-        tracks.get_track_id("1_2") != 1
-    )  # give sibling new id again (not necessarily 2)
+    assert tracks.get_track_id(2) != 1  # give sibling new id again (not necessarily 2)
     assert tracks.graph.number_of_edges() == num_edges

--- a/tests/motile/backend/test_motile_run.py
+++ b/tests/motile/backend/test_motile_run.py
@@ -1,5 +1,6 @@
 import networkx as nx
 import numpy as np
+
 from motile_tracker.motile.backend import MotileRun, SolverParams
 
 

--- a/tests/motile/backend/test_motile_run.py
+++ b/tests/motile/backend/test_motile_run.py
@@ -4,9 +4,9 @@ from motile_tracker.motile.backend import MotileRun, SolverParams
 
 
 def test_save_load(tmp_path, graph_2d):
-    segmentation = np.zeros((10, 1, 10, 10))
+    segmentation = np.zeros((10, 10, 10))
     for i in range(10):
-        segmentation[i][:, 0:5, 0:5] = i
+        segmentation[i][0:5, 0:5] = i
 
     run_name = "test"
     scale = [1.0, 2.0, 3.0]

--- a/tests/motile/backend/test_solver.py
+++ b/tests/motile/backend/test_solver.py
@@ -3,7 +3,7 @@ from motile_tracker.motile.backend import SolverParams, solve
 
 # capsys is a pytest fixture that captures stdout and stderr output streams
 def test_solve_2d(segmentation_2d, graph_2d):
-    graph_2d.remove_nodes_from([2, 4, 5])
+    graph_2d.remove_nodes_from([4, 5, 6])
     params = SolverParams()
     params.appear_cost = None
     soln_graph = solve(params, segmentation_2d)

--- a/tests/motile/menus/test_run_editor.py
+++ b/tests/motile/menus/test_run_editor.py
@@ -1,0 +1,9 @@
+from motile_tracker.motile.menus.run_editor import RunEditor
+
+
+def test__has_duplicate_labels(segmentation_2d):
+    assert not RunEditor._has_duplicate_ids(segmentation_2d)
+    frame = segmentation_2d[1]
+    frame[frame == 2] = 1
+    segmentation_2d[1] = frame
+    assert RunEditor._has_duplicate_ids(segmentation_2d)

--- a/tests/motile_plugin/utils/test_tree_widget_utils.py
+++ b/tests/motile_plugin/utils/test_tree_widget_utils.py
@@ -1,6 +1,7 @@
 import napari
 import pandas as pd
 from motile_toolbox.visualization.napari_utils import assign_tracklet_ids
+
 from motile_tracker.data_model import SolutionTracks
 from motile_tracker.data_views.views.tree_view.tree_widget_utils import (
     extract_sorted_tracks,

--- a/tests/motile_plugin/utils/test_tree_widget_utils.py
+++ b/tests/motile_plugin/utils/test_tree_widget_utils.py
@@ -10,8 +10,8 @@ from motile_tracker.data_views.views.tree_view.tree_widget_utils import (
 def test_track_df(graph_2d):
     tracks = SolutionTracks(graph=graph_2d, ndim=3)
 
-    assert tracks.get_area("0_1") == 1245
-    assert tracks.get_area("1_2") is None
+    assert tracks.get_area(1) == 1245
+    assert tracks.get_area(2) is None
 
     tracks.graph, _, _ = assign_tracklet_ids(tracks.graph)
 
@@ -23,6 +23,6 @@ def test_track_df(graph_2d):
 
     track_df = extract_sorted_tracks(tracks, colormap)
     assert isinstance(track_df, pd.DataFrame)
-    assert track_df.loc[track_df["node_id"] == "0_1", "area"].values[0] == 1245
-    assert track_df.loc[track_df["node_id"] == "1_2", "area"].values[0] == 0
+    assert track_df.loc[track_df["node_id"] == 1, "area"].values[0] == 1245
+    assert track_df.loc[track_df["node_id"] == 2, "area"].values[0] == 0
     assert track_df["area"].notna().all()


### PR DESCRIPTION
This is a minimal working update for our new toolbox version (no hypothesis dimension, unique segmentation IDs and int node ids). I did not actually update the visualization code to use the unique seg ids - it still relabels the segmentation before viewing. All the backend tests pass (in fact, most of the code changes were updating the tests to use the new integer node ids). I tested the UI components, but only a little.

I still want to implement a function that will check if the input labels layer has repeat IDs across time and relabels them (with the already implemented function in the toolbox), to make sure we can still input e.g. cellpose labels that have been predicted independently for each time point. 

Edit: I added the function, and a function that will check if there are duplicate labels across time. Right now that lives in the RunEditor and just compares the labels of the first two frames of the segmentation, to avoid looping over the whole time series.