### PR TITLE
provide scale to point and graph layer

### DIFF
--- a/src/motile_tracker/data_views/views/layers/track_graph.py
+++ b/src/motile_tracker/data_views/views/layers/track_graph.py
@@ -77,6 +77,7 @@ class TrackGraph(napari.layers.Tracks):
         self,
         name: str,
         tracks_viewer: TracksViewer,
+        scale: tuple,
     ):
         self.tracks_viewer = tracks_viewer
         track_data, track_edges = update_napari_tracks(
@@ -89,6 +90,7 @@ class TrackGraph(napari.layers.Tracks):
             name=name,
             tail_length=3,
             color_by="track_id",
+            scale = scale,
         )
 
         self.colormaps_dict["track_id"] = self.tracks_viewer.colormap

--- a/src/motile_tracker/data_views/views/layers/track_points.py
+++ b/src/motile_tracker/data_views/views/layers/track_points.py
@@ -27,6 +27,7 @@ class TrackPoints(napari.layers.Points):
         self,
         name: str,
         tracks_viewer: TracksViewer,
+        scale: tuple,
     ):
         self.tracks_viewer = tracks_viewer
         self.nodes = list(tracks_viewer.tracks.graph.nodes)
@@ -56,6 +57,7 @@ class TrackPoints(napari.layers.Points):
             },  # TODO: use features
             border_color=[1, 1, 1, 1],
             blending="translucent_no_depth",
+            scale = scale,
         )
 
         # Key bindings (should be specified both on the viewer (in tracks_viewer)

--- a/src/motile_tracker/data_views/views/layers/tracks_layer_group.py
+++ b/src/motile_tracker/data_views/views/layers/tracks_layer_group.py
@@ -55,11 +55,13 @@ class TracksLayerGroup:
             self.tracks_layer = TrackGraph(
                 name=self.name + "_tracks",
                 tracks_viewer=self.tracks_viewer,
+                scale=self.tracks.scale,
             )
 
             self.points_layer = TrackPoints(
                 name=self.name + "_points",
                 tracks_viewer=self.tracks_viewer,
+                scale=self.tracks.scale,
             )
         else:
             self.tracks_layer = None


### PR DESCRIPTION
I was encountering a bug that when I provided a `scale` to `SolutionTracks`, that scale was only propagated into `TrackLabels`, not into `TrackGraph` and `TrackPoints`. For a 3D dataset, this meant that the points and graph were spatially not aligned with the Labels.

In this PR, I provide the scale parameter to `TrackGraph` and `TrackPoints`, in the same way as previously done to `TrackLabels`. It works for my use case (where I use `TreeWidget` and `EditingMenu` in isolation), so please confirm that it works properly in the full `motile-tracker` widget. 

Note: I think the scale doesn't necessarily have to be an extra parameters, but could also be taken from `self.tracks_viewer.tracks.scale`

Let me know if I can change/add anything, and feel free to take over this PR if it involves bigger changes. 
