### PR TITLE
fix - yellow selection rectangles persist on screen

### DIFF
--- a/src/motile_tracker/data_views/views/tree_view/tree_widget.py
+++ b/src/motile_tracker/data_views/views/tree_view/tree_widget.py
@@ -53,25 +53,36 @@ class CustomViewBox(pg.ViewBox):
         """Modified mouseDragEvent function to check which mouse mode to use
         and to submit rectangle coordinates for selecting multiple nodes if necessary"""
 
-        super().mouseDragEvent(ev, axis)
+        #check if SHIFT is pressed
+        shift_down = (ev.modifiers() == QtCore.Qt.ShiftModifier)
 
-        # use RectMode when pressing shift
-        if ev.modifiers() == QtCore.Qt.ShiftModifier:
-            self.setMouseMode(self.RectMode)
-
+        if shift_down:
+            # if starting a shift-drag, record the scene position
             if ev.isStart():
                 self.mouse_start_pos = self.mapSceneToView(ev.scenePos())
-            elif ev.isFinish():
+
+            # Put the ViewBox in RectMode so it draws its usual yellow rectangle
+            self.setMouseMode(self.RectMode)
+            super().mouseDragEvent(ev, axis)
+
+            # Once the drag finishes, emit the rectangle
+            if ev.isFinish():
                 rect_end_pos = self.mapSceneToView(ev.scenePos())
                 rect = QtCore.QRectF(self.mouse_start_pos, rect_end_pos).normalized()
                 self.selected_rect.emit(rect)  # emit the rectangle
                 ev.accept()
-            else:
-                ev.ignore()
-        else:
-            # Otherwise, set pan mode
-            self.setMouseMode(self.PanMode)
 
+                if hasattr(self, 'rbScaleBox') and self.rbScaleBox:
+                    self.rbScaleBox.hide()
+
+        else:
+            # SHIFT not pressed - use PanMode normally
+            self.setMouseMode(self.PanMode)
+            super().mouseDragEvent(ev, axis)
+
+            #hide the leftover box if any
+            if hasattr(self, 'rbScaleBox') and self.rbScaleBox:
+                self.rbScaleBox.hide()
 
 class TreePlot(pg.PlotWidget):
     node_clicked = Signal(Any, bool)  # node_id, append


### PR DESCRIPTION
This PR fixes a problem that I encountered (both on Mac and Linux) with the yellow selection rectangles in `tree_widget`. The problem is that yellow selection rectangles stay persistently on the screen (see video below) when a click-drag events happens after shift is releasd.

**Problem** 
After a shift+drag event in which the user box-selects a number of points: when shift is no longer pressed, and the user clicks+drags somewhere on the canvas (without shift), it still creates a very small yellow rectangle that stays there forever. Nothing is selected,that is all fine, it is just the remaining yellow rectangle that stays in the view forever. (just aesthetics, nothing functionally wrong)

**Solution**
In this PR, I changed `mouseDragEvent` in `tree_widget.py`, so it first detect whether `SHIFT` is pressed before deciding which action to take (normal dragging vs. selection). There might be other solutions to this problem, so feel free to add/adjust, but at least this worked for me. 

https://github.com/user-attachments/assets/3b82e0ed-1ba5-486b-90d8-b147cefee965
