### PR TITLE
block current_size event signals in TrackPoints when adding or selecting points

### DIFF
--- a/src/motile_tracker/data_views/views/layers/track_points.py
+++ b/src/motile_tracker/data_views/views/layers/track_points.py
@@ -116,6 +116,7 @@ class TrackPoints(napari.layers.Points):
 
         with self.events.current_size.blocker():
             super().add(coords)
+
     def process_click(self, event: Event, point_index: int | None):
         """Select the clicked point(s)"""
 


### PR DESCRIPTION
This is to not accidentally increase the point size with every selection/add point click. (partially) solves #237 