### PR TITLE
use LITT function to determine order of tracks,

### DIFF
--- a/src/motile_tracker/data_views/_tests/test_tree_widget_utils.py
+++ b/src/motile_tracker/data_views/_tests/test_tree_widget_utils.py
@@ -140,7 +140,7 @@ def test_track_df(graph_2d):
         background_value=0,
     )
 
-    track_df = extract_sorted_tracks(tracks, colormap)
+    track_df, _ = extract_sorted_tracks(tracks, colormap)
     assert isinstance(track_df, pd.DataFrame)
     assert track_df.loc[track_df["node_id"] == 1, "area"].values[0] == 1245
     assert track_df.loc[track_df["node_id"] == 2, "area"].values[0] == 0

--- a/src/motile_tracker/data_views/views/tree_view/tree_widget.py
+++ b/src/motile_tracker/data_views/views/tree_view/tree_widget.py
@@ -614,14 +614,14 @@ class TreeWidget(QWidget):
             self.graph = None
         else:
             if reset_view:
-                self.track_df = extract_sorted_tracks(
+                self.track_df, self.axis_order = extract_sorted_tracks(
                     self.tracks_viewer.tracks, self.tracks_viewer.colormap
                 )
             else:
-                self.track_df = extract_sorted_tracks(
+                self.track_df, self.axis_order = extract_sorted_tracks(
                     self.tracks_viewer.tracks,
                     self.tracks_viewer.colormap,
-                    self.track_df,
+                    self.axis_order,
                 )
             self.graph = self.tracks_viewer.tracks.graph
 


### PR DESCRIPTION
Also optionally supply the previous order, to minimize tracks jumping to the end of the tree. 
The `get_sorted_tracks` function needed to be adjusted to iterate over the nodes by topological order (using `nx.topological_sort(graph)`), because when deleting an entire track, and undoing that action, the nodes are added back in reverse order, and because of that the parent tracklet is not correctly determined. 

This PR should also fix a bug I just discovered on Main: when you delete an entire lineage, except for one node, the application freezes on calculating the tree 😬 