### PR TITLE
Bugfix: clear collectionwidget.selected_collection

### DIFF
--- a/src/motile_tracker/data_views/views_coordinator/groups.py
+++ b/src/motile_tracker/data_views/views_coordinator/groups.py
@@ -249,6 +249,7 @@ class CollectionWidget(QWidget):
 
         # first clear the entire list
         self.collection_list.clear()
+        self.selected_collection = None  # set back to None
 
         # find existing group features on Tracks
         group_features = [


### PR DESCRIPTION
Ensure that collectionwidget.selected_collection is cleared when switching between tracks or creating new tracks.

Otherwise, it may trigger a KeyError error when creating new tracks and switching to group mode, as it is trying to access non existing nodes from the group from previous tracks.

`While emitting signal 'list_updated', an error occurred in a callback:
  KeyError: 5632`