### PR TITLE
Make sure that out of slice point display is restricted to the z dimension

### DIFF
--- a/src/motile_tracker/data_views/views/layers/out_of_slice_points.py
+++ b/src/motile_tracker/data_views/views/layers/out_of_slice_points.py
@@ -1,0 +1,109 @@
+from dataclasses import dataclass
+
+import numpy as np
+import numpy.typing as npt
+from napari.layers import Points
+from napari.layers.points._slice import _PointSliceRequest
+
+
+@dataclass(frozen=True)
+class _ZOnlyPointSliceRequest(_PointSliceRequest):
+    def _get_slice_data(self, not_disp: list[int]) -> tuple[npt.NDArray, int]:
+        """Modified _get_slice_data function from napari's _PointSliceRequest to apply the out-of-slice display logic only along the last non displayed axis, assumed to be z.
+
+        Args: not_disp (list[int]): List of non-displayed dimensions (e.g. [0, 1] for t, z)
+
+        Returns: tuple[npt.NDArray, int]: A tuple containing the indices of the points that are inside the slice and the scale factor for out-of-slice points.
+        """
+
+        data = self.data[:, not_disp]
+        ndim = len(not_disp)
+
+        # Last axis = spill axis
+        spill_dim = ndim - 1
+        filter_dims = list(range(spill_dim))
+
+        scale = 1
+
+        point, m_left, m_right = self.data_slice[not_disp].as_array()
+
+        # Filter points that are outside the slice along any non-spill axis
+        inside_mask = np.ones(len(data), dtype=bool)
+
+        for ax in filter_dims:
+            low = point[ax] - m_left[ax]
+            high = point[ax] + m_right[ax]
+
+            if np.isclose(low, high):
+                low -= 0.5
+                high += 0.5
+
+            inside_mask &= (data[:, ax] >= low) & (data[:, ax] <= high)
+
+        if not np.any(inside_mask):
+            return np.empty(0, dtype=int), 1
+
+        # Normal slice behavior within masked region, but only along spill axis
+        if self.projection_mode == "none":
+            low = point.copy()
+            high = point.copy()
+        else:
+            low = point - m_left
+            high = point + m_right
+
+        too_thin = np.isclose(high, low)
+        low[too_thin] -= 0.5
+        high[too_thin] += 0.5
+
+        inside_full = np.all((data >= low) & (data <= high), axis=1)
+
+        # Must satisfy strict filtering dims
+        inside_slice = inside_mask & inside_full
+        slice_indices = np.where(inside_slice)[0].astype(int)
+
+        # Out of slice display along spill axis only
+        if self.out_of_slice_display and self.slice_input.ndim > 2:
+            # Only candidates that pass strict filtering dims
+            candidate_mask = inside_mask
+            if not np.any(candidate_mask):
+                return np.empty(0, dtype=int), 1
+
+            sizes = self.size[candidate_mask] / 2
+            spill_values = data[candidate_mask, spill_dim]
+
+            low_spill = low[spill_dim]
+            high_spill = high[spill_dim]
+
+            dist_from_low = np.abs(spill_values - low_spill)
+            dist_from_high = np.abs(spill_values - high_spill)
+            distances = np.minimum(dist_from_low, dist_from_high)
+
+            # points fully inside slice along spill axis
+            inside_spill = (spill_values >= low_spill) & (spill_values <= high_spill)
+            distances[inside_spill] = 0
+
+            matches = distances <= sizes
+            if not np.any(matches):
+                return np.empty(0, dtype=int), 1
+
+            size_match = sizes[matches]
+            scale = (size_match - distances[matches]) / size_match
+
+            candidate_indices = np.where(candidate_mask)[0]
+            slice_indices = candidate_indices[matches]
+
+        return slice_indices.astype(int), scale
+
+
+class ZOnlyPoints(Points):
+    """Points subclass that overrides the slice request to apply the out-of-slice display logic only along the last non displayed axis."""
+
+    def _make_slice_request_internal(self, slice_input, data_slice):
+        return _ZOnlyPointSliceRequest(
+            slice_input=slice_input,
+            data=self.data,
+            data_slice=data_slice,
+            projection_mode=self.projection_mode,
+            out_of_slice_display=self.out_of_slice_display,
+            size=self.size,
+        )

--- a/src/motile_tracker/data_views/views/layers/track_points.py
+++ b/src/motile_tracker/data_views/views/layers/track_points.py
@@ -30,6 +30,8 @@ if TYPE_CHECKING:
 
     from motile_tracker.data_views.views_coordinator.tracks_viewer import TracksViewer
 
+from motile_tracker.data_views.views.layers.out_of_slice_points import ZOnlyPoints
+
 
 def custom_select(layer: napari.layers.Points, event: Event):
     """Block the current_size signal when selecting points to avoid changing the point
@@ -39,7 +41,7 @@ def custom_select(layer: napari.layers.Points, event: Event):
         yield from select(layer, event)
 
 
-class TrackPoints(napari.layers.Points):
+class TrackPoints(ZOnlyPoints):
     """Extended points layer that holds the track information and emits and
     responds to dynamics visualization signals
     """

--- a/src/motile_tracker/data_views/views/ortho_views.py
+++ b/src/motile_tracker/data_views/views/ortho_views.py
@@ -16,6 +16,7 @@ from motile_tracker.data_views.views.layers.click_utils import (
     get_click_value,
 )
 from motile_tracker.data_views.views.layers.contour_labels import ContourLabels
+from motile_tracker.data_views.views.layers.out_of_slice_points import ZOnlyPoints
 from motile_tracker.data_views.views.layers.track_graph import TrackGraph
 from motile_tracker.data_views.views.layers.track_labels import TrackLabels
 from motile_tracker.data_views.views.layers.track_points import TrackPoints
@@ -50,7 +51,7 @@ def copy_layer(layer: Layer, name: str = ""):
         res_layer._redo_history = layer._redo_history
 
     elif isinstance(layer, TrackPoints):
-        res_layer = Points(
+        res_layer = ZOnlyPoints(
             data=layer.data,
             name=layer.name,
         )
@@ -117,20 +118,20 @@ sync_filters = {
 # Define special functions to allow specific behavior on special layer types (TrackLabels,
 # and TrackPoints)
 #
-def point_data_hook(orig_layer: TrackPoints, copied_layer: Points) -> None:
+def point_data_hook(orig_layer: TrackPoints, copied_layer: ZOnlyPoints) -> None:
     """Hook to connect to sync points data and visualization between original and copied
     Points layers.
 
     Args:
         orig_layer (TrackPoints): TracksLabels layer from which the copied layer is
             derived.
-        copied_layer (Points): Points equivalent of the TracksPoints layer.
+        copied_layer (ZOnlyPoints): ZOnlyPoints equivalent of the TracksPoints layer.
     """
 
     # Sync the shown points and their size, as it is not synced by default. We bind to the
     # border_color event as this this is emitted when we modify shown points and point
     # size on the TrackPoints layer.
-    def sync_shown_points(orig_layer: TrackPoints, copied_layer: Points) -> None:
+    def sync_shown_points(orig_layer: TrackPoints, copied_layer: ZOnlyPoints) -> None:
         """Sync the visible points between original TrackPoints layer and Points layers
         in ViewerModel instances (this is not a synced property)"""
 
@@ -146,7 +147,7 @@ def point_data_hook(orig_layer: TrackPoints, copied_layer: Points) -> None:
     orig_layer.events.border_color.connect(shown_points_wrapper)
 
     # Receive data updates from the original layer
-    def receive_data(orig_layer: TrackPoints, copied_layer: Points) -> None:
+    def receive_data(orig_layer: TrackPoints, copied_layer: ZOnlyPoints) -> None:
         """Respond to signal from the original layer, to update the data"""
 
         copied_layer.events.data.disconnect(copied_layer._sync_data_wrapper)
@@ -160,9 +161,9 @@ def point_data_hook(orig_layer: TrackPoints, copied_layer: Points) -> None:
 
     # Sync the event that is emitted when a point is moved or deleted. We need to capture
     # it on the original layer to process it there, and potentially undo it if it was an
-    # invalid action (we have no way to judge that on a normal Points layer).
+    # invalid action (we have no way to judge that on a normal ZOnlyPoints layer).
     def sync_data_event(
-        orig_layer: TrackPoints, copied_layer: Points, event: Event
+        orig_layer: TrackPoints, copied_layer: ZOnlyPoints, event: Event
     ) -> None:
         """Send the event that is emitted when a point is moved or deleted to the original
         layer"""
@@ -254,22 +255,22 @@ def colormap_hook(orig_layer: TrackLabels, copied_layer: Labels) -> None:
 
 
 def track_layers_hook(
-    orig_layer: TrackLabels | TrackPoints, copied_layer: Labels | Points
+    orig_layer: TrackLabels | TrackPoints, copied_layer: Labels | ZOnlyPoints
 ) -> None:
     """Hook to capture click events on TrackLabels and TrackPoints derived Labels and
-    Points layers, and forward them to their original layer. Also, register key binds
+    ZOnlyPoints layers, and forward them to their original layer. Also, register key binds
     for view mode, undo & redo to copied layer, that call functions on the original layer.
 
     Args:
         orig_layer (TrackLabels | TrackPoints): TracksLabels or TrackPoints layer from
             which the copied layer is derived.
-        copied_layer (Labels | Points): Labels or Points equivalent of the TracksLabels
+        copied_layer (Labels | ZOnlyPoints): Labels or ZOnlyPoints equivalent of the TracksLabels
             or TrackPoints layer.
     """
 
     # define the click behavior the layer should respond to
     def click(
-        orig_layer: TrackLabels | TrackPoints, layer: Labels | Points, event: Event
+        orig_layer: TrackLabels | TrackPoints, layer: Labels | ZOnlyPoints, event: Event
     ):
         if layer.mode == "pan_zoom":
             was_click = yield from detect_click(event)


### PR DESCRIPTION
Make another Points subclass that overwrites the out-of-slice display logic and restrict it to the last non-displayed dim. Use it for orthoviews and TrackPoints

Partial fix for #238
