### PR TITLE
use bulk UserUpdateNodesAttrs to speed up adding/removing nodes from/to groups

### DIFF
--- a/src/motile_tracker/data_views/views_coordinator/groups.py
+++ b/src/motile_tracker/data_views/views_coordinator/groups.py
@@ -315,13 +315,13 @@ class CollectionWidget(QWidget):
                 self.selected_collection.collection | set(nodes)
             )
 
-            # Use UpdateNodeAttrs to set the feature value to True
+            # Use UpdateNodesAttrs to set the feature value to True
             feature_key = self.selected_collection.name.text()
 
             UserUpdateNodesAttrs(
                 tracks=self.tracks_viewer.tracks,
                 nodes=nodes,
-                attrs={feature_key: True},
+                attrs={feature_key: [True for _ in nodes]},
             )
 
             self.group_changed.emit()
@@ -398,11 +398,10 @@ class CollectionWidget(QWidget):
             }
 
             feature_key = self.selected_collection.name.text()
-            # attrs = {feature_key: [False for _ in nodes]}
             UserUpdateNodesAttrs(
                 tracks=self.tracks_viewer.tracks,
                 nodes=nodes,
-                attrs={feature_key: False},
+                attrs={feature_key: [False for _ in nodes]},
             )
 
             self.group_changed.emit()

--- a/src/motile_tracker/data_views/views_coordinator/groups.py
+++ b/src/motile_tracker/data_views/views_coordinator/groups.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any
 
 from fonticon_fa6 import FA6S
 from funtracks.features._feature import Feature
-from funtracks.user_actions import UserUpdateNodeAttrs
+from funtracks.user_actions import UserUpdateNodesAttrs
 from napari._qt.qt_resources import QColoredSVGIcon
 from qtpy.QtCore import Signal
 from qtpy.QtWidgets import (
@@ -317,12 +317,12 @@ class CollectionWidget(QWidget):
 
             # Use UpdateNodeAttrs to set the feature value to True
             feature_key = self.selected_collection.name.text()
-            for node in nodes:
-                UserUpdateNodeAttrs(
-                    tracks=self.tracks_viewer.tracks,
-                    node=node,
-                    attrs={feature_key: True},
-                )
+
+            UserUpdateNodesAttrs(
+                tracks=self.tracks_viewer.tracks,
+                nodes=nodes,
+                attrs={feature_key: True},
+            )
 
             self.group_changed.emit()
 
@@ -399,12 +399,11 @@ class CollectionWidget(QWidget):
 
             feature_key = self.selected_collection.name.text()
             # attrs = {feature_key: [False for _ in nodes]}
-            for node in nodes:
-                UserUpdateNodeAttrs(
-                    tracks=self.tracks_viewer.tracks,
-                    node=node,
-                    attrs={feature_key: False},
-                )
+            UserUpdateNodesAttrs(
+                tracks=self.tracks_viewer.tracks,
+                nodes=nodes,
+                attrs={feature_key: False},
+            )
 
             self.group_changed.emit()
 


### PR DESCRIPTION
To fix the slow processing of adding/removing lineages to groups in last release before v2