### PR TITLE
[WIP] make cand_graph persistent/once, not for each solve

### DIFF
--- a/src/motile_tracker/motile/menus/motile_widget.py
+++ b/src/motile_tracker/motile/menus/motile_widget.py
@@ -2,6 +2,7 @@
 
 import logging
 
+import tracksdata as td
 from funtracks.data_model import SolutionTracks
 from funtracks.utils import ensure_unique_labels
 from napari import Viewer
@@ -37,6 +38,8 @@ class MotileWidget(QWidget):
     def __init__(self, viewer: Viewer):
         super().__init__()
         self.viewer: Viewer = viewer
+        self._cand_graph: td.graph.GraphView | None = None
+        self._cand_graph_key: tuple | None = None
         tracks_viewer = TracksViewer.get_instance(self.viewer)
         self.new_run.connect(tracks_viewer.tracks_list.add_tracks)
         tracks_viewer.tracks_list.view_tracks.connect(self.view_run)
@@ -84,6 +87,26 @@ class MotileWidget(QWidget):
         if run:
             self.edit_run_widget.new_run(run)
 
+    def _make_cand_graph_key(self, run: MotileRun) -> tuple:
+        """Return a cache key that captures everything that determines candidate graph structure.
+
+        The candidate graph depends on the input data identity, max_edge_distance, and
+        whether IOU is computed. Cost parameters (appear_cost, division_cost, etc.) do
+        NOT affect the graph structure, so they are excluded from the key.
+        """
+        data = (
+            run.input_segmentation
+            if run.input_segmentation is not None
+            else run.input_points
+        )
+        return (
+            data.shape,
+            str(data.dtype),
+            id(data),  # shape+dtype guard against id reuse across different arrays
+            run.solver_params.max_edge_distance,
+            run.solver_params.iou_cost is not None,
+        )
+
     def _generate_tracks(self, run: MotileRun) -> None:
         """Called when we start solving a new run. Switches from run editor to run
         viewer and starts solving of the new run in a separate thread to avoid blocking
@@ -119,17 +142,39 @@ class MotileWidget(QWidget):
         else:
             raise ValueError("Must have one of input segmentation or points")
 
-        try:
-            cand_graph = build_candidate_graph(input_data, run.solver_params, run.scale)
-        except ValueError as e:
-            if "Duplicate values found among nodes" in str(e):
-                run.input_segmentation = ensure_unique_labels(run.input_segmentation)
-                input_data = run.input_segmentation
+        key = self._make_cand_graph_key(run)
+        if self._cand_graph is not None and self._cand_graph_key == key:
+            logger.info(
+                "Reusing cached candidate graph (%d nodes, %d edges)",
+                self._cand_graph.num_nodes(),
+                self._cand_graph.num_edges(),
+            )
+            cand_graph = self._cand_graph
+        else:
+            logger.info("Building candidate graph...")
+            try:
                 cand_graph = build_candidate_graph(
                     input_data, run.solver_params, run.scale
                 )
-            else:
-                raise
+            except ValueError as e:
+                if "Duplicate values found among nodes" in str(e):
+                    run.input_segmentation = ensure_unique_labels(
+                        run.input_segmentation
+                    )
+                    input_data = run.input_segmentation
+                    key = self._make_cand_graph_key(run)
+                    cand_graph = build_candidate_graph(
+                        input_data, run.solver_params, run.scale
+                    )
+                else:
+                    raise
+            self._cand_graph = cand_graph
+            self._cand_graph_key = key
+            logger.info(
+                "Candidate graph built: %d nodes, %d edges",
+                cand_graph.num_nodes(),
+                cand_graph.num_edges(),
+            )
 
         solution_graph = solve(
             run.solver_params,

--- a/tests/motile/menus/test_motile_widget.py
+++ b/tests/motile/menus/test_motile_widget.py
@@ -151,6 +151,7 @@ def test_solve_with_motile(make_napari_viewer, segmentation_2d):
         solver_params=SolverParams(),
         ndim=3,
     )
+    widget._cand_graph = None  # clear cache so build_candidate_graph is called
     with (
         patch(
             "motile_tracker.motile.menus.motile_widget.build_candidate_graph"
@@ -172,6 +173,7 @@ def test_solve_with_motile(make_napari_viewer, segmentation_2d):
         run_name="test_run",
         solver_params=SolverParams(),
     )
+    widget._cand_graph = None  # clear cache so build_candidate_graph is called
     with (
         patch(
             "motile_tracker.motile.menus.motile_widget.build_candidate_graph"
@@ -196,6 +198,7 @@ def test_solve_with_motile(make_napari_viewer, segmentation_2d):
         solver_params=SolverParams(),
     )
 
+    widget._cand_graph = None  # clear cache so build_candidate_graph is called
     with (
         patch(
             "motile_tracker.motile.menus.motile_widget.build_candidate_graph"


### PR DESCRIPTION
The candidate graph was rebuilt from scratch on every "Run Tracking" click, even when only cost parameters changed. This PR caches it in `MotileWidget` and reuses it as long as the parameters that affect graph structure haven't changed.

**What invalidates the cache** (graph structure depends on these):
- Input data identity (shape, dtype, object id)
- `max_edge_distance`
- `iou_cost` on/off

**What doesn't invalidate it** (solver-only parameters):
- `appear_cost`, `division_cost`, `distance_cost`, `edge_selection_cost`, `max_children`, window params

**Changes:**
- `motile_widget.py`: add `_cand_graph`/`_cand_graph_key`, `_make_cand_graph_key()`, replace always-rebuild block with cache check
- `test_motile_widget.py`: reset cache between sub-tests that patch `build_candidate_graph` (the shared widget instance was getting cache hits across sub-tests)
