### PR TITLE
handle features without display_name

### DIFF
--- a/src/motile_tracker/data_views/views/tree_view/tree_widget_utils.py
+++ b/src/motile_tracker/data_views/views/tree_view/tree_widget_utils.py
@@ -349,11 +349,11 @@ def get_features_from_tracks(
         features_to_ignore = []
     features_to_plot = []
     if tracks is not None:
-        for feature in tracks.features.values():
+        for key, feature in tracks.features.items():
             # Skip edge features - only show node features in dropdown
             if feature["feature_type"] == "edge":
                 continue
-            name = feature["display_name"]
+            name = feature.get("display_name", key)
             if feature["value_type"] in ("float", "int"):
                 if feature["num_values"] > 1:
                     value_names = feature.get("value_names", None)

--- a/tests/data_views/views/tree_view/test_tree_widget_utils.py
+++ b/tests/data_views/views/tree_view/test_tree_widget_utils.py
@@ -2,10 +2,13 @@ import napari
 import pandas as pd
 import polars as pl
 from funtracks.annotators import TrackAnnotator
+from funtracks.data_model import SolutionTracks
 from funtracks.features import Feature
+from funtracks.utils.tracksdata_utils import create_empty_graphview_graph
 
 from motile_tracker.data_views.views.tree_view.tree_widget_utils import (
     extract_sorted_tracks,
+    get_features_from_tracks,
 )
 
 
@@ -35,3 +38,26 @@ def test_track_df(solution_tracks_2d):
     assert isinstance(track_df, pd.DataFrame)
     assert track_df.loc[track_df["node_id"] == 1, "custom_attr"].values[0] == 10
     assert track_df.loc[track_df["node_id"] == 2, "custom_attr"].values[0] == 0
+
+
+def test_get_features_from_tracks_individual_pos_attrs():
+    """get_features_from_tracks must not crash when pos_attr is a list.
+
+    When SolutionTracks is built with pos_attr=["y", "x"], funtracks registers
+    each axis as a Feature without a display_name key (NotRequired per the TypedDict).
+    The function must fall back to the dict key instead of raising KeyError.
+    """
+    graph = create_empty_graphview_graph(
+        node_attributes=["y", "x"],
+        ndim=3,
+    )
+    graph.bulk_add_nodes(
+        nodes=[{"t": 0, "y": 10.0, "x": 20.0, "solution": 1}],
+        indices=[1],
+    )
+    tracks = SolutionTracks(graph=graph, ndim=3, time_attr="t", pos_attr=["y", "x"])
+
+    features = get_features_from_tracks(tracks)
+
+    assert "y" in features
+    assert "x" in features


### PR DESCRIPTION
`get_features_from_tracks` required the features to have a `display_name`, which is not always the case, since this field is `NotRequired` in `funtracks`. This PR solves this requirement by using the `key` as the `display_name` when the `FeatureDict` doesn't have a `display_name`