### PR TITLE
enforce the TrackList to only contain MotileRun objects

### DIFF
--- a/src/motile_tracker/data_views/views_coordinator/tracks_list.py
+++ b/src/motile_tracker/data_views/views_coordinator/tracks_list.py
@@ -136,21 +136,7 @@ class TracksList(QGroupBox):
             tracks = dialog.tracks
             name = dialog.name
             if tracks is not None:
-                # Wrap the imported SolutionTracks in a MotileRun so the list
-                # invariant (every item is a MotileRun) holds. solver_params is
-                # None because these tracks never went through the solver.
-                run = MotileRun(
-                    graph=tracks.graph,
-                    run_name=name,
-                    solver_params=None,
-                    pos_attr=tracks.features.position_key,
-                    time_attr=tracks.features.time_key,
-                    scale=tracks.scale,
-                    ndim=tracks.ndim,
-                    _features=tracks.features,
-                    _segmentation=tracks.segmentation,
-                )
-                self.add_tracks(run, name, select=True)
+                self.add_tracks(tracks, name, select=True)
 
     def _selection_changed(self):
         selected = self.tracks_list.selectedItems()
@@ -158,25 +144,34 @@ class TracksList(QGroupBox):
             tracks_button = self.tracks_list.itemWidget(selected[0])
             self.view_tracks.emit(tracks_button.tracks, tracks_button.name.text())
 
-    def add_tracks(self, tracks: MotileRun, name: str, select=True):
+    def add_tracks(self, tracks: Tracks, name: str, select=True):
         """Add a run to the list and optionally select it. Will make a new
         row in the list UI representing the given run.
+
+        Accepts any Tracks object. Plain Tracks/SolutionTracks are wrapped in
+        a MotileRun (with solver_params=None) so the list internally always
+        holds MotileRun and save_tracks can rely on tracks.save().
 
         Note: selecting the run will also emit the selection changed event on
         the list.
 
         Args:
-            tracks (MotileRun): the run to add to the results list. Must be a
-                MotileRun (importers wrap their SolutionTracks output before
-                calling this) so save_tracks can rely on tracks.save().
+            tracks (Tracks): the tracks object to add to the results list.
             name (str): the name of the tracks to display
             select (bool, optional): Whether or not to select the new tracks item in the
                 list (and thus display it in the tracks viewer). Defaults to True.
         """
         if not isinstance(tracks, MotileRun):
-            raise TypeError(
-                f"TracksList only holds MotileRun objects, got {type(tracks).__name__}. "
-                "Wrap imported SolutionTracks in a MotileRun before calling add_tracks."
+            tracks = MotileRun(
+                graph=tracks.graph,
+                run_name=name,
+                solver_params=None,
+                pos_attr=tracks.features.position_key,
+                time_attr=tracks.features.time_key,
+                scale=tracks.scale,
+                ndim=tracks.ndim,
+                _features=tracks.features,
+                _segmentation=tracks.segmentation,
             )
         item = QListWidgetItem(self.tracks_list)
         tracks_row = TracksButton(tracks, name)

--- a/src/motile_tracker/data_views/views_coordinator/tracks_list.py
+++ b/src/motile_tracker/data_views/views_coordinator/tracks_list.py
@@ -136,7 +136,21 @@ class TracksList(QGroupBox):
             tracks = dialog.tracks
             name = dialog.name
             if tracks is not None:
-                self.add_tracks(tracks, name, select=True)
+                # Wrap the imported SolutionTracks in a MotileRun so the list
+                # invariant (every item is a MotileRun) holds. solver_params is
+                # None because these tracks never went through the solver.
+                run = MotileRun(
+                    graph=tracks.graph,
+                    run_name=name,
+                    solver_params=None,
+                    pos_attr=tracks.features.position_key,
+                    time_attr=tracks.features.time_key,
+                    scale=tracks.scale,
+                    ndim=tracks.ndim,
+                    _features=tracks.features,
+                    _segmentation=tracks.segmentation,
+                )
+                self.add_tracks(run, name, select=True)
 
     def _selection_changed(self):
         selected = self.tracks_list.selectedItems()
@@ -144,7 +158,7 @@ class TracksList(QGroupBox):
             tracks_button = self.tracks_list.itemWidget(selected[0])
             self.view_tracks.emit(tracks_button.tracks, tracks_button.name.text())
 
-    def add_tracks(self, tracks: Tracks, name: str, select=True):
+    def add_tracks(self, tracks: MotileRun, name: str, select=True):
         """Add a run to the list and optionally select it. Will make a new
         row in the list UI representing the given run.
 
@@ -152,11 +166,18 @@ class TracksList(QGroupBox):
         the list.
 
         Args:
-            tracks (Tracks): the tracks object to add to the results list
+            tracks (MotileRun): the run to add to the results list. Must be a
+                MotileRun (importers wrap their SolutionTracks output before
+                calling this) so save_tracks can rely on tracks.save().
             name (str): the name of the tracks to display
             select (bool, optional): Whether or not to select the new tracks item in the
                 list (and thus display it in the tracks viewer). Defaults to True.
         """
+        if not isinstance(tracks, MotileRun):
+            raise TypeError(
+                f"TracksList only holds MotileRun objects, got {type(tracks).__name__}. "
+                "Wrap imported SolutionTracks in a MotileRun before calling add_tracks."
+            )
         item = QListWidgetItem(self.tracks_list)
         tracks_row = TracksButton(tracks, name)
         self.tracks_list.setItemWidget(item, tracks_row)

--- a/src/motile_tracker/motile/backend/motile_run.py
+++ b/src/motile_tracker/motile/backend/motile_run.py
@@ -183,33 +183,35 @@ class MotileRun(SolutionTracks):
 
     def _save_params(self, run_dir: Path):
         """Save the run parameters in the provided run directory. Currently
-        dumps the parameters dict into a json file.
+        dumps the parameters dict into a json file. Skips writing if there are
+        no params (e.g. tracks imported from CSV/geff that never went through
+        the solver).
 
         Args:
             run_dir (Path): A directory in which to save the parameters file.
         """
+        if self.solver_params is None:
+            return
         params_file = run_dir / PARAMS_FILENAME
         with open(params_file, "w") as f:
             json.dump(self.solver_params.__dict__, f)
 
     @staticmethod
-    def _load_params(run_dir: Path) -> SolverParams:
+    def _load_params(run_dir: Path) -> SolverParams | None:
         """Load parameters from the parameters json file in the provided
-        directory.
+        directory. Returns None if the file is absent — runs imported from
+        CSV/geff are saved without solver params.
 
         Args:
             run_dir (Path): The directory in which to find the parameters file.
 
-        Raises:
-            FileNotFoundError: If the parameters file is not found in the
-                provided directory.
-
         Returns:
-            SolverParams: The solver parameters loaded from disk.
+            SolverParams | None: The solver parameters, or None if no params
+                file exists in the run directory.
         """
         params_file = run_dir / PARAMS_FILENAME
         if not params_file.is_file():
-            raise FileNotFoundError(f"Parameters not found at {params_file}")
+            return None
         with open(params_file) as f:
             params_dict = json.load(f)
         return SolverParams(**params_dict)
@@ -325,7 +327,8 @@ class MotileRun(SolutionTracks):
         """
         base_path = Path(base_path)
         run_dir = base_path / self._make_id()
-        # Lets be safe and remove the expected files and then the directory
-        (run_dir / PARAMS_FILENAME).unlink()
-        (run_dir / GAPS_FILENAME).unlink()
+        # Lets be safe and remove the expected files and then the directory.
+        # Both files are optional (params for imported runs, gaps when None).
+        (run_dir / PARAMS_FILENAME).unlink(missing_ok=True)
+        (run_dir / GAPS_FILENAME).unlink(missing_ok=True)
         super().delete(run_dir)

--- a/src/motile_tracker/motile/menus/run_editor.py
+++ b/src/motile_tracker/motile/menus/run_editor.py
@@ -230,7 +230,9 @@ class RunEditor(QGroupBox):
 
     def new_run(self, run: MotileRun) -> None:
         """Configure the run editor to copy the name and params of the given
-        run.
+        run. Imported runs (CSV/geff) have no solver_params — leave the
+        editor at its current values rather than emitting None.
         """
         self.run_name.setText(run.run_name)
-        self.solver_params_widget.new_params.emit(run.solver_params)
+        if run.solver_params is not None:
+            self.solver_params_widget.new_params.emit(run.solver_params)

--- a/src/motile_tracker/motile/menus/run_viewer.py
+++ b/src/motile_tracker/motile/menus/run_viewer.py
@@ -55,7 +55,13 @@ class RunViewer(QGroupBox):
         run_name_view = f"{run.run_name} ({run_time})"
         self.setTitle("Run Viewer: " + run_name_view)
         self.solver_event_update()
-        self.params_widget.new_params.emit(run.solver_params)
+        # Imported runs (CSV/geff) have no solver_params — hide the params
+        # display rather than emit None into widgets that can't render it.
+        if run.solver_params is None:
+            self.params_widget.hide()
+        else:
+            self.params_widget.show()
+            self.params_widget.new_params.emit(run.solver_params)
 
     def _back_to_edit_widget(self) -> QWidget:
         """Create a widget for navigating back to the run editor with different

--- a/tests/data_views/views_coordinator/test_tracks_list.py
+++ b/tests/data_views/views_coordinator/test_tracks_list.py
@@ -91,7 +91,7 @@ class TestTracksListAddRemove:
 
 
 class TestTracksListSave:
-    def test_save_tracks_calls_save_when_dialog_accepted(
+    def test_save_tracks_writes_run_dir_when_dialog_accepted(
         self, tracks_list, tracks, tmp_path
     ):
         tracks_list.add_tracks(tracks, "run1", select=False)
@@ -100,19 +100,63 @@ class TestTracksListSave:
         tracks_list.save_dialog.exec_ = MagicMock(return_value=True)
         tracks_list.save_dialog.selectedFiles = MagicMock(return_value=[str(tmp_path)])
 
-        with patch.object(tracks, "save") as mock_save:
-            tracks_list.save_tracks(item)
-            mock_save.assert_called_once_with(tmp_path)
+        tracks_list.save_tracks(item)
 
-    def test_save_tracks_does_nothing_when_dialog_rejected(self, tracks_list, tracks):
+        saved_dirs = [p for p in tmp_path.iterdir() if p.is_dir()]
+        assert len(saved_dirs) == 1
+
+    def test_save_tracks_does_nothing_when_dialog_rejected(
+        self, tracks_list, tracks, tmp_path
+    ):
         tracks_list.add_tracks(tracks, "run1", select=False)
         item = tracks_list.tracks_list.item(0)
 
         tracks_list.save_dialog.exec_ = MagicMock(return_value=False)
 
-        with patch.object(tracks, "save") as mock_save:
-            tracks_list.save_tracks(item)
-            mock_save.assert_not_called()
+        tracks_list.save_tracks(item)
+
+        assert list(tmp_path.iterdir()) == []
+
+
+# ---------------------------------------------------------------------------
+# TracksList — imported (non-MotileRun) tracks must be saveable
+# ---------------------------------------------------------------------------
+
+
+class TestTracksListSaveImported:
+    def test_imported_solution_tracks_can_be_saved(
+        self, tracks_list, solution_tracks_2d, tmp_path
+    ):
+        """Tracks loaded via ImportDialog (a SolutionTracks, not a MotileRun)
+        must still be saveable via the save button.
+
+        Reproduces the AttributeError seen when saving CSV-imported tracks:
+        the import path must wrap the SolutionTracks in a MotileRun so
+        save_tracks → tracks.save(directory) works.
+        """
+        mock_dialog = MagicMock()
+        mock_dialog.exec_.return_value = QDialog.Accepted
+        mock_dialog.tracks = solution_tracks_2d
+        mock_dialog.name = "imported"
+
+        with patch(
+            "motile_tracker.data_views.views_coordinator.tracks_list.ImportDialog",
+            return_value=mock_dialog,
+        ):
+            tracks_list._load_tracks("csv")
+
+        item = tracks_list.tracks_list.item(0)
+        widget = tracks_list.tracks_list.itemWidget(item)
+        assert isinstance(widget.tracks, MotileRun)
+        assert widget.tracks.solver_params is None
+
+        tracks_list.save_dialog.exec_ = MagicMock(return_value=True)
+        tracks_list.save_dialog.selectedFiles = MagicMock(return_value=[str(tmp_path)])
+
+        tracks_list.save_tracks(item)
+
+        saved_dirs = [p for p in tmp_path.iterdir() if p.is_dir()]
+        assert len(saved_dirs) == 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #401 

Solves the problem that when tracks are loaded from CSV/GEFF, the item in `TrackList` is a `SolutionTracks` object, and this doesn't have a `.save` method; only `MotileRun` has that. So this gives a bug when the "Save Tracks" button in pressed.  

Solution:
- force all entrees in `TrackList` to be `MotileRun` objects
- this is essentially no difference, except that `solver_params` is None
- this requires some small changes in saving/loading the `solver_param`

