### PR TITLE
fix brush painting with preserve_labels=True

### DIFF
--- a/src/motile_tracker/data_views/views/layers/contour_labels.py
+++ b/src/motile_tracker/data_views/views/layers/contour_labels.py
@@ -8,7 +8,9 @@ from napari.layers.labels._labels_constants import (
 from napari.layers.labels._labels_mouse_bindings import draw, pick
 from napari.layers.labels._labels_utils import (
     expand_slice,
+    indices_in_shape,
 )
+from napari.layers.labels.labels import _coerce_indices_for_vectorization
 from napari.utils import DirectLabelColormap
 from napari.utils._indexing import elements_in_slice, index_in_slice
 from napari.utils.events import Event
@@ -172,6 +174,60 @@ class ContourLabels(napari.layers.Labels):
         """Refresh the label colormap by setting its dictionary"""
 
         self.colormap = DirectLabelColormap(color_dict=self.colormap.color_dict)
+
+    def _paint_indices(
+        self,
+        mask_indices,
+        new_label,
+        shape,
+        dims_to_paint,
+        slice_coord=None,
+        refresh=True,
+    ):
+        """Paint variant that supports read-only data (e.g. GraphArrayView).
+
+        Only diverges from napari's default for the one case it can't handle:
+        a read-only array with `preserve_labels=True`, where the upstream
+        path does fancy indexing (`self.data[slice_coord]`) that tracksdata's
+        lazy view doesn't support. In that case we materialize per-time-frame
+        via `_read_old_values`. All other cases delegate to super.
+        """
+        if hasattr(self.data, "__setitem__") or not self.preserve_labels:
+            return super()._paint_indices(
+                mask_indices, new_label, shape, dims_to_paint, slice_coord, refresh
+            )
+
+        # Read-only + preserve_labels: mirror napari's setup, then build
+        # keep_coords from materialized frame values instead of fancy-indexing
+        # self.data.
+        dims_not_painted = sorted(self._slice_input.order[: -self.n_edit_dimensions])
+        mask_indices = indices_in_shape(mask_indices, shape)
+
+        slice_coord_temp = list(mask_indices.T)
+        if self.n_edit_dimensions < self.ndim:
+            for j, i in enumerate(dims_to_paint):
+                slice_coord[i] = slice_coord_temp[j]
+            for i in dims_not_painted:
+                slice_coord[i] = slice_coord[i] * np.ones(
+                    mask_indices.shape[0], dtype=int
+                )
+        else:
+            slice_coord = slice_coord_temp
+
+        slice_coord = _coerce_indices_for_vectorization(self.data, slice_coord)
+
+        current_values = self._read_old_values(slice_coord)
+        if new_label == self.colormap.background_value:
+            keep_coords = current_values == (
+                self._prev_selected_label
+                if self._prev_selected_label
+                else self.selected_label
+            )
+        else:
+            keep_coords = current_values == self.colormap.background_value
+        slice_coord = tuple(sc[keep_coords] for sc in slice_coord)
+
+        self.data_setitem(slice_coord, new_label, refresh)
 
     def data_setitem(self, indices, value, refresh=True):
         """Override to handle read-only data (e.g. GraphArrayView).

--- a/tests/data_views/test_track_labels.py
+++ b/tests/data_views/test_track_labels.py
@@ -250,6 +250,75 @@ def test_data_setitem_empty_indices_does_not_raise(
         seg_layer.data_setitem(empty_indices, 1)
 
 
+def test_paint_with_preserve_labels_paints_into_background(
+    viewer, solution_tracks_3d_with_division
+):
+    """Brush + preserve_labels=True on read-only GraphArrayView must paint
+    background pixels.
+
+    Regression: pre-fix, GraphArrayView fancy-indexing returned a view rather
+    than values, keep_coords collapsed to False, and the brush silently
+    no-oped under preserve_labels. The ContourLabels._paint_indices override
+    materializes per-time-frame to compute keep_coords correctly.
+    """
+    tracks_viewer = TracksViewer.get_instance(viewer)
+    tracks_viewer.update_tracks(tracks=solution_tracks_3d_with_division, name="test")
+    seg_layer = tracks_viewer.tracking_layers.seg_layer
+
+    step = list(viewer.dims.current_step)
+    step[0] = 0  # node 1 lives at t=0, bbox 45-54^3
+    viewer.dims.current_step = step
+
+    new_label(seg_layer)
+    new_value = seg_layer.selected_label
+
+    seg_layer.preserve_labels = True
+    seg_layer.brush_size = 3
+
+    nodes_before = tracks_viewer.tracks.graph.num_nodes()
+
+    # Pure background: far from node 1
+    seg_layer.paint(np.array([0, 50, 80, 80]), new_value)
+
+    # Segmentation: painted pixel shows new_value
+    assert int(np.asarray(seg_layer.data[0, 50, 80, 80])) == new_value
+    # Existing node 1 untouched
+    assert int(np.asarray(seg_layer.data[0, 50, 50, 50])) == 1
+    # Graph: new node added
+    assert tracks_viewer.tracks.graph.num_nodes() == nodes_before + 1
+
+
+def test_paint_with_preserve_labels_does_not_overwrite_existing(
+    viewer, solution_tracks_3d_with_division
+):
+    """Brush + preserve_labels=True must not overwrite existing labels.
+
+    Same override path as the background test, but keep_coords excludes every
+    candidate pixel, so neither segmentation nor graph should change.
+    """
+    tracks_viewer = TracksViewer.get_instance(viewer)
+    tracks_viewer.update_tracks(tracks=solution_tracks_3d_with_division, name="test")
+    seg_layer = tracks_viewer.tracking_layers.seg_layer
+
+    step = list(viewer.dims.current_step)
+    step[0] = 0
+    viewer.dims.current_step = step
+
+    new_label(seg_layer)
+    new_value = seg_layer.selected_label
+
+    seg_layer.preserve_labels = True
+    seg_layer.brush_size = 3
+
+    nodes_before = tracks_viewer.tracks.graph.num_nodes()
+
+    # Center of node 1
+    seg_layer.paint(np.array([0, 50, 50, 50]), new_value)
+
+    assert int(np.asarray(seg_layer.data[0, 50, 50, 50])) == 1
+    assert tracks_viewer.tracks.graph.num_nodes() == nodes_before
+
+
 def test_undo_on_readonly_data_does_not_fire_paint_event(
     viewer, solution_tracks_3d_with_division
 ):


### PR DESCRIPTION
## Bug

With `preserve_labels=True` enabled, the brush did nothing on `TrackLabels` layers backed by tracksdata's `GraphArrayView`. No crash, no paint, no graph change. With `preserve_labels=False` it worked fine.

## Root cause

napari's `Labels._paint_indices` computes which pixels to keep via:

```python
keep_coords = self.data[slice_coord] == background_value
```

For numpy arrays this is standard fancy indexing returning values. `GraphArrayView` is a lazy view — its `__getitem__` returns *another sliced view*, not values. With no `__eq__` defined, the comparison falls back to `False`, every `sc[False]` becomes empty, and `data_setitem` is called with no pixels.

## Fix

Override `_paint_indices` on `ContourLabels`. The override only diverges from napari for the one case it can't handle — read-only data + `preserve_labels=True` — and uses `_read_old_values` to materialize one time-frame at a time (via the supported `self.data[int(t)]` access pattern) to compute `keep_coords` correctly. Every other branch (writable data, or `preserve_labels=False`) delegates straight to `super()`.