### PR TITLE
Fix import dialog (optional properties stacking on top of each other)

### DIFF
--- a/src/motile_tracker/import_export/menus/prop_map_widget.py
+++ b/src/motile_tracker/import_export/menus/prop_map_widget.py
@@ -210,20 +210,35 @@ class StandardFieldMapWidget(QWidget):
         self.setVisible(True)
 
     def _update_props_left(self) -> None:
-        """Update the list of columns that have not been mapped yet"""
+        """Update the list of columns that have not been mapped yet
 
+        Remove attributes from optional features if they are mapped in the mandatory
+        mapping.
+        """
+
+        # Get all mapped values from the mandatory mapping
+        mapped_mandatory = {
+            combo.currentText()
+            for combo in self.mapping_widgets.values()
+            if combo.currentText() != "None"
+        }
+
+        # Remove from optional features if mapped in mandatory mapping
         self.props_left = [
-            attr for attr in self.node_attrs if attr not in self.get_name_map().values()
+            attr for attr in self.node_attrs if attr not in mapped_mandatory
         ]
 
         optional_features = list(self.optional_features.keys())
         for attribute in optional_features:
-            if attribute not in self.props_left:
+            if attribute not in self.props_left and attribute in mapped_mandatory:
                 self._remove_optional_prop(attribute)
 
         for attribute in self.props_left:
             if attribute not in self.optional_features:
                 self._add_optional_prop(attribute)
+
+        # update duplicate check
+        self._check_for_duplicates()
 
     def _get_initial_mapping(self) -> dict[str, str]:
         """Make an initial guess for mapping of geff columns to fields"""
@@ -288,7 +303,13 @@ class StandardFieldMapWidget(QWidget):
             attribute (str): The attribute name to add as an optional feature
         """
 
-        row_idx = len(self.optional_features) + 1  # +1 for header row
+        # Compute the row index based on the current state of the layout, skipping already
+        # present widgets and header row, to prevent stacking widgets on top of each other.
+        row_idx = 1
+        for i, attr in enumerate(self.props_left):
+            if attr == attribute:
+                row_idx = i + 1  # +1 for header row
+                break
 
         # Prop checkbox
         attr_checkbox = QCheckBox(attribute)


### PR DESCRIPTION
Fix updating the optional property widgets, to ensure all properties are present exactly once (either in the mandatory fields, or in the optional fields) and never stacked on top of each other.

closes #414 