### PR TITLE
Wrap the GraphArrayView to mock fancy indexing with individual pixel access

### DIFF
--- a/src/motile_tracker/data_views/lazy_array_wrapper.py
+++ b/src/motile_tracker/data_views/lazy_array_wrapper.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import numpy as np
+
+
+def _is_fancy_index(index):
+    """Return True if index is a fancy index (tuple containing array-likes)."""
+    if not isinstance(index, tuple):
+        return False
+    return any(isinstance(i, (np.ndarray, list)) for i in index)
+
+
+class LazyArrayWrapper:
+    """Wrapper around lazy/read-only arrays that materializes fancy indexing.
+
+    Lazy array backends like tracksdata's GraphArrayView return view objects
+    from __getitem__ rather than numpy values. This breaks napari code that
+    does fancy indexing (e.g. ``data[tuple_of_arrays] == value``).
+
+    This wrapper intercepts fancy indexing and materializes one
+    first-dimension slice at a time, returning numpy values. All other
+    indexing patterns and attribute access are delegated to the underlying
+    array.
+
+    The wrapper intentionally does not implement __setitem__, preserving the
+    read-only nature of the underlying array for detection via
+    ``hasattr(data, "__setitem__")``.
+    """
+
+    def __init__(self, data):
+        self._data = data
+
+    @property
+    def wrapped(self):
+        """The underlying array object."""
+        return self._data
+
+    @property
+    def shape(self):
+        return self._data.shape
+
+    @property
+    def dtype(self):
+        return self._data.dtype
+
+    @property
+    def ndim(self):
+        return self._data.ndim
+
+    @property
+    def size(self):
+        return self._data.size
+
+    def __len__(self):
+        return len(self._data)
+
+    def __array__(self, dtype=None, copy=None):
+        return np.array(self._data, dtype=dtype, copy=copy)
+
+    def __getitem__(self, index):
+        if _is_fancy_index(index):
+            return self._materialize_fancy(index)
+        return self._data[index]
+
+    def _materialize_fancy(self, index):
+        """Materialize fancy indexing by reading individual coordinates.
+
+        Each coordinate tuple is looked up via scalar indexing on the
+        underlying array, which is fast when the array has an internal
+        cache (e.g. GraphArrayView's NDChunkCache).
+        """
+        arrays = tuple(np.asarray(i) for i in index)
+        n = len(arrays[0])
+        result = np.empty(n, dtype=self._data.dtype)
+        for i in range(n):
+            coord = tuple(int(a[i]) for a in arrays)
+            result[i] = np.asarray(self._data[coord])
+        return result
+
+    def __getattr__(self, name):
+        return getattr(self._data, name)
+
+    def __repr__(self):
+        return f"LazyArrayWrapper({self._data!r})"

--- a/src/motile_tracker/data_views/lazy_array_wrapper.py
+++ b/src/motile_tracker/data_views/lazy_array_wrapper.py
@@ -69,6 +69,9 @@ class LazyArrayWrapper:
         underlying array, which is fast when the array has an internal
         cache (e.g. GraphArrayView's NDChunkCache).
         """
+        # O(n) Python loop of scalar lookups: fine for brush strokes (few
+        # pixels), but a large preserve_labels op (e.g. a bucket-fill over a
+        # big region) iterates over every candidate pixel and may be slow.
         arrays = tuple(np.asarray(i) for i in index)
         n = len(arrays[0])
         result = np.empty(n, dtype=self._data.dtype)
@@ -78,6 +81,12 @@ class LazyArrayWrapper:
         return result
 
     def __getattr__(self, name):
+        # Guard against infinite recursion if _data is missing (e.g. during
+        # copy/pickle, which build the instance without calling __init__).
+        # (only matters if in the future we make the segLayer copyable/picklable/deepcopyable,
+        # which we currently don't, but this is a good safeguard in case we do)
+        if name == "_data":
+            raise AttributeError(name)
         return getattr(self._data, name)
 
     def __repr__(self):

--- a/src/motile_tracker/data_views/views/layers/contour_labels.py
+++ b/src/motile_tracker/data_views/views/layers/contour_labels.py
@@ -14,6 +14,8 @@ from napari.utils._indexing import elements_in_slice, index_in_slice
 from napari.utils.events import Event
 from scipy import ndimage as ndi
 
+from motile_tracker.data_views.lazy_array_wrapper import LazyArrayWrapper
+
 
 def left_only_draw(layer, event):
     if event.button != 1:
@@ -76,6 +78,12 @@ class ContourLabels(napari.layers.Labels):
     def _type_string(self) -> str:
         return "labels"  # to make sure that the layer is treated as labels layer for saving
 
+    @napari.layers.Labels.data.setter
+    def data(self, data):
+        if not isinstance(data, LazyArrayWrapper) and not hasattr(data, "__setitem__"):
+            data = LazyArrayWrapper(data)
+        napari.layers.Labels.data.fset(self, data)
+
     def __init__(
         self,
         data: np.array,
@@ -84,6 +92,8 @@ class ContourLabels(napari.layers.Labels):
         scale: tuple,
         colormap: DirectLabelColormap,
     ):
+        if not isinstance(data, LazyArrayWrapper) and not hasattr(data, "__setitem__"):
+            data = LazyArrayWrapper(data)
         super().__init__(
             data=data,
             name=name,
@@ -182,7 +192,7 @@ class ContourLabels(napari.layers.Labels):
         For writable arrays (numpy), fall back to the default implementation.
         """
         if not hasattr(self.data, "__setitem__"):
-            old_values = self._read_old_values(indices)
+            old_values = self.data[indices]
             atom = (indices, old_values, value)
             if self._block_history:
                 # During a drag, accumulate atoms; events.paint fires once on release
@@ -267,15 +277,3 @@ class ContourLabels(napari.layers.Labels):
             self.refresh()
         else:
             super().undo()
-
-    def _read_old_values(self, indices):
-        """Read current values at indices from a read-only array,
-        materializing one timepoint at a time (the only supported access pattern)."""
-        t_indices = indices[0]
-        spatial_indices = indices[1:]
-        old_values = np.zeros(len(t_indices), dtype=np.int64)
-        for t in np.unique(t_indices):
-            mask = t_indices == t
-            frame = np.asarray(self.data[int(t)])
-            old_values[mask] = frame[tuple(s[mask] for s in spatial_indices)]
-        return old_values

--- a/src/motile_tracker/data_views/views/layers/track_labels.py
+++ b/src/motile_tracker/data_views/views/layers/track_labels.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING
 
 import napari
 import numpy as np
-import tracksdata as td
 from funtracks.exceptions import InvalidActionError
 from funtracks.user_actions import UserUpdateSegmentation
 from napari.layers import Labels
@@ -57,22 +56,15 @@ def _new_label(layer: TrackLabels, new_track_id=True):
             it to the selected_track attribute. Defaults to True.
     """
 
-    if isinstance(layer.data, td.array.GraphArrayView):
-        new_selected_label = (
-            max(layer.tracks_viewer.tracks.graph.node_ids(), default=0) + 1
-        )
-        if new_track_id or layer.tracks_viewer.selected_track is None:
-            layer.tracks_viewer.set_new_track_id()
-        layer.selected_label = new_selected_label
-        layer.colormap.color_dict[new_selected_label] = (
-            layer.tracks_viewer.track_id_color
-        )
-        # to refresh, otherwise you paint with a transparent label until you
-        # release the mouse
-        with layer.events.selected_label.blocker():
-            layer.colormap = DirectLabelColormap(color_dict=layer.colormap.color_dict)
-    else:
-        show_info("Calculating empty label on non-numpy array is not supported")
+    new_selected_label = max(layer.tracks_viewer.tracks.graph.node_ids(), default=0) + 1
+    if new_track_id or layer.tracks_viewer.selected_track is None:
+        layer.tracks_viewer.set_new_track_id()
+    layer.selected_label = new_selected_label
+    layer.colormap.color_dict[new_selected_label] = layer.tracks_viewer.track_id_color
+    # to refresh, otherwise you paint with a transparent label until you
+    # release the mouse
+    with layer.events.selected_label.blocker():
+        layer.colormap = DirectLabelColormap(color_dict=layer.colormap.color_dict)
 
 
 class TrackLabels(ContourLabels):

--- a/tests/data_views/test_lazy_array_wrapper.py
+++ b/tests/data_views/test_lazy_array_wrapper.py
@@ -1,0 +1,201 @@
+import numpy as np
+import pytest
+
+from motile_tracker.data_views.lazy_array_wrapper import (
+    LazyArrayWrapper,
+    _is_fancy_index,
+)
+
+
+class FakeLazyArray:
+    """Minimal lazy array that mimics GraphArrayView behaviour.
+
+    __getitem__ always returns another FakeLazyArray (never numpy values),
+    so fancy indexing followed by == would fail without the wrapper.
+    """
+
+    def __init__(self, data: np.ndarray):
+        self._data = data
+
+    @property
+    def shape(self):
+        return self._data.shape
+
+    @property
+    def dtype(self):
+        return self._data.dtype
+
+    @property
+    def ndim(self):
+        return self._data.ndim
+
+    @property
+    def size(self):
+        return self._data.size
+
+    def __len__(self):
+        return len(self._data)
+
+    def __getitem__(self, index):
+        if isinstance(index, int):
+            return self._data[index]
+        return FakeLazyArray(self._data[index])
+
+    def __array__(self, dtype=None, copy=None):
+        return np.array(self._data, dtype=dtype, copy=copy)
+
+
+@pytest.fixture
+def sample_data():
+    """4D array: 3 timeframes, 2x4x4 spatial."""
+    rng = np.random.default_rng(42)
+    return rng.integers(0, 10, size=(3, 2, 4, 4), dtype=np.int64)
+
+
+@pytest.fixture
+def lazy(sample_data):
+    return FakeLazyArray(sample_data)
+
+
+@pytest.fixture
+def wrapped(lazy):
+    return LazyArrayWrapper(lazy)
+
+
+class TestIsFancyIndex:
+    def test_tuple_of_arrays(self):
+        idx = (np.array([0, 1]), np.array([2, 3]))
+        assert _is_fancy_index(idx) is True
+
+    def test_tuple_with_list(self):
+        idx = ([0, 1], [2, 3])
+        assert _is_fancy_index(idx) is True
+
+    def test_scalar(self):
+        assert _is_fancy_index(5) is False
+
+    def test_slice(self):
+        assert _is_fancy_index(slice(0, 3)) is False
+
+    def test_tuple_of_scalars(self):
+        assert _is_fancy_index((0, 1, 2)) is False
+
+    def test_tuple_of_slices(self):
+        assert _is_fancy_index((slice(0, 2), slice(1, 3))) is False
+
+    def test_mixed_with_array(self):
+        idx = (0, np.array([1, 2]))
+        assert _is_fancy_index(idx) is True
+
+
+class TestDelegation:
+    def test_shape(self, wrapped, sample_data):
+        assert wrapped.shape == sample_data.shape
+
+    def test_dtype(self, wrapped, sample_data):
+        assert wrapped.dtype == sample_data.dtype
+
+    def test_ndim(self, wrapped, sample_data):
+        assert wrapped.ndim == sample_data.ndim
+
+    def test_size(self, wrapped, sample_data):
+        assert wrapped.size == sample_data.size
+
+    def test_len(self, wrapped, sample_data):
+        assert len(wrapped) == len(sample_data)
+
+    def test_asarray(self, wrapped, sample_data):
+        result = np.asarray(wrapped)
+        np.testing.assert_array_equal(result, sample_data)
+
+    def test_wrapped_property(self, wrapped, lazy):
+        assert wrapped.wrapped is lazy
+
+
+class TestGetitem:
+    def test_scalar_index_delegates(self, wrapped, sample_data):
+        frame = wrapped[0]
+        np.testing.assert_array_equal(np.asarray(frame), sample_data[0])
+
+    def test_slice_index_delegates(self, wrapped, sample_data):
+        result = wrapped[0:2]
+        np.testing.assert_array_equal(np.asarray(result), sample_data[0:2])
+
+    def test_fancy_index_returns_numpy(self, wrapped, sample_data):
+        t = np.array([0, 0, 1, 2])
+        z = np.array([0, 1, 0, 1])
+        y = np.array([0, 1, 2, 3])
+        x = np.array([0, 1, 2, 3])
+        result = wrapped[(t, z, y, x)]
+        expected = sample_data[t, z, y, x]
+        assert isinstance(result, np.ndarray)
+        np.testing.assert_array_equal(result, expected)
+
+    def test_fancy_index_single_timeframe(self, wrapped, sample_data):
+        t = np.array([1, 1, 1])
+        z = np.array([0, 0, 1])
+        y = np.array([0, 1, 2])
+        x = np.array([0, 1, 3])
+        result = wrapped[(t, z, y, x)]
+        expected = sample_data[t, z, y, x]
+        np.testing.assert_array_equal(result, expected)
+
+    def test_fancy_index_empty_arrays(self, wrapped):
+        empty = np.array([], dtype=np.int64)
+        result = wrapped[(empty, empty, empty, empty)]
+        assert isinstance(result, np.ndarray)
+        assert len(result) == 0
+
+    def test_fancy_index_with_lists(self, wrapped, sample_data):
+        result = wrapped[([0, 1], [0, 1], [0, 1], [0, 1])]
+        expected = sample_data[[0, 1], [0, 1], [0, 1], [0, 1]]
+        assert isinstance(result, np.ndarray)
+        np.testing.assert_array_equal(result, expected)
+
+    def test_fancy_index_comparison_works(self, wrapped, sample_data):
+        """The original bug: fancy_index then == should produce a boolean array."""
+        t = np.array([0, 0, 1])
+        z = np.array([0, 0, 0])
+        y = np.array([0, 1, 2])
+        x = np.array([0, 1, 3])
+        result = wrapped[(t, z, y, x)] == 0
+        expected = sample_data[t, z, y, x] == 0
+        assert isinstance(result, np.ndarray)
+        assert result.dtype == bool
+        np.testing.assert_array_equal(result, expected)
+
+
+class TestReadOnly:
+    def test_no_setitem(self, wrapped):
+        assert not hasattr(wrapped, "__setitem__")
+
+    def test_no_double_wrap(self, wrapped):
+        double = LazyArrayWrapper(wrapped)
+        # wrapping a wrapper is allowed but not intended;
+        # the data property setter on ContourLabels guards against it
+        assert double.wrapped is wrapped
+
+
+class TestGetattr:
+    def test_forwards_unknown_attributes(self):
+        """__getattr__ should forward to the underlying array."""
+
+        class ArrayWithExtra:
+            shape = (3, 4)
+            dtype = np.int64
+            ndim = 2
+            size = 12
+            custom_attr = "hello"
+
+            def __len__(self):
+                return 3
+
+            def __getitem__(self, index):
+                return self
+
+            def __array__(self, dtype=None, copy=None):
+                return np.zeros(self.shape, dtype=dtype)
+
+        arr = ArrayWithExtra()
+        wrapped = LazyArrayWrapper(arr)
+        assert wrapped.custom_attr == "hello"

--- a/tests/data_views/test_track_labels.py
+++ b/tests/data_views/test_track_labels.py
@@ -253,6 +253,75 @@ def test_data_setitem_empty_indices_does_not_raise(
         seg_layer.data_setitem(empty_indices, 1)
 
 
+def test_paint_with_preserve_labels_paints_into_background(
+    viewer, solution_tracks_3d_with_division
+):
+    """Brush + preserve_labels=True on read-only GraphArrayView must paint
+    background pixels.
+
+    Regression: pre-fix, GraphArrayView fancy-indexing returned a view rather
+    than values, keep_coords collapsed to False, and the brush silently
+    no-oped under preserve_labels. The LazyArrayWrapper materializes
+    per-timeframe so napari's default _paint_indices works correctly.
+    """
+    tracks_viewer = TracksViewer.get_instance(viewer)
+    tracks_viewer.update_tracks(tracks=solution_tracks_3d_with_division, name="test")
+    seg_layer = tracks_viewer.tracking_layers.seg_layer
+
+    step = list(viewer.dims.current_step)
+    step[0] = 0  # node 1 lives at t=0, bbox 45-54^3
+    viewer.dims.current_step = step
+
+    new_label(seg_layer)
+    new_value = seg_layer.selected_label
+
+    seg_layer.preserve_labels = True
+    seg_layer.brush_size = 3
+
+    nodes_before = tracks_viewer.tracks.graph.num_nodes()
+
+    # Pure background: far from node 1
+    seg_layer.paint(np.array([0, 50, 80, 80]), new_value)
+
+    # Segmentation: painted pixel shows new_value
+    assert int(np.asarray(seg_layer.data[0, 50, 80, 80])) == new_value
+    # Existing node 1 untouched
+    assert int(np.asarray(seg_layer.data[0, 50, 50, 50])) == 1
+    # Graph: new node added
+    assert tracks_viewer.tracks.graph.num_nodes() == nodes_before + 1
+
+
+def test_paint_with_preserve_labels_does_not_overwrite_existing(
+    viewer, solution_tracks_3d_with_division
+):
+    """Brush + preserve_labels=True must not overwrite existing labels.
+
+    Same override path as the background test, but keep_coords excludes every
+    candidate pixel, so neither segmentation nor graph should change.
+    """
+    tracks_viewer = TracksViewer.get_instance(viewer)
+    tracks_viewer.update_tracks(tracks=solution_tracks_3d_with_division, name="test")
+    seg_layer = tracks_viewer.tracking_layers.seg_layer
+
+    step = list(viewer.dims.current_step)
+    step[0] = 0
+    viewer.dims.current_step = step
+
+    new_label(seg_layer)
+    new_value = seg_layer.selected_label
+
+    seg_layer.preserve_labels = True
+    seg_layer.brush_size = 3
+
+    nodes_before = tracks_viewer.tracks.graph.num_nodes()
+
+    # Center of node 1
+    seg_layer.paint(np.array([0, 50, 50, 50]), new_value)
+
+    assert int(np.asarray(seg_layer.data[0, 50, 50, 50])) == 1
+    assert tracks_viewer.tracks.graph.num_nodes() == nodes_before
+
+
 def test_undo_on_readonly_data_does_not_fire_paint_event(
     viewer, solution_tracks_3d_with_division
 ):


### PR DESCRIPTION
Closes #404  (alternative to #412 )

The root of the problem is that GraphArrayView doesn't allow fancy indexing. This solution wraps GraphArrayView in a LazyArrayWrapper that does the fancy indexing by accessing the individual pixels under the paint event. This can be used when constructing the Masks from the drag event, as well as when checking preserve_labels=True, and is much faster than the previous workaround of materializing the whole time frame.