### PR TITLE
remove dot outline in treeview

### DIFF
--- a/src/motile_tracker/data_views/views/tree_view/tree_widget.py
+++ b/src/motile_tracker/data_views/views/tree_view/tree_widget.py
@@ -344,7 +344,7 @@ class TreePlot(pg.PlotWidget):
             self.adj = edges_df_mapped.to_numpy()
 
         self.outline_pen = np.array(
-            [pg.mkPen(QColor(150, 150, 150)) for i in range(len(self._pos))]
+            [pg.mkPen(QColor(150, 150, 150, 0)) for i in range(len(self._pos))]
         )
 
     def set_selection(self, selected_nodes: list[Any], plot_type: str) -> None:


### PR DESCRIPTION
Problem was that every dot has a gret outline. When having many cells, we only see the outlines and the dot colors are no longer visible. This PR solves this by setting the opacity of the outline to 0. The blue highlight upon node selection still works.

Before:

<img width="283" height="277" alt="Screenshot 2026-07-02 at 14 08 32" src="https://github.com/user-attachments/assets/312913b5-413c-4e12-8dc7-c7d613962b97" />

After:

<img width="262" height="184" alt="Screenshot 2026-07-02 at 14 20 14" src="https://github.com/user-attachments/assets/ce1f1c31-db64-4d16-93a4-d423a3219862" />
