### PR TITLE
UI benchmarks

### DIFF
--- a/.github/workflows/benchmark-report.yml
+++ b/.github/workflows/benchmark-report.yml
@@ -1,0 +1,47 @@
+name: Benchmark
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  deployments: write
+  contents: write
+
+jobs:
+  benchmark:
+    name: Report benchmarks on gh-pages
+    runs-on: ubuntu-latest
+    env:
+      UV_NO_SYNC: "1"
+    steps:
+      - uses: actions/checkout@v6
+      - uses: tlambert03/setup-qt-libs@v1
+
+      - name: Set up Python
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.13"
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --no-dev --group testing
+
+      # tests/benchmarks is ignored by default pytest config; `-o addopts=` clears
+      # that. GUI benchmarks need a real GL context, hence aganders3/headless-gui.
+      - name: Run benchmarks
+        uses: aganders3/headless-gui@v2
+        with:
+          run: uv run pytest tests/benchmarks -o addopts= --benchmark-json output.json
+
+      - name: Store benchmark results
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: motile_tracker benchmarks (pytest-benchmark)
+          tool: "pytest"
+          output-file-path: output.json
+          benchmark-data-dir-path: benchmarks
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true

--- a/.github/workflows/benchmark_pr.py
+++ b/.github/workflows/benchmark_pr.py
@@ -1,0 +1,97 @@
+"""Compare two pytest-benchmark JSON files and produce a markdown table.
+
+Usage:
+    python benchmark_pr.py <old.json> <new.json> <output.md> [header]
+
+Exits with code 1 if any benchmark regresses by more than REGRESSION_THRESHOLD.
+"""
+
+import json
+import os
+import sys
+
+import pandas as pd
+
+REGRESSION_THRESHOLD = 50  # percent
+
+
+def load_stats(path):
+    with open(path) as f:
+        data = json.load(f)
+
+    commit = data["commit_info"]["id"]
+
+    rows = []
+    for d in data["benchmarks"]:
+        rows.append({"Benchmark": d["name"], "mean": d["stats"]["mean"]})
+
+    return commit, pd.DataFrame(rows)
+
+
+def _write(out_file, report):
+    with open(out_file, "w") as f:
+        f.write(report)
+    print(report)  # noqa: T201
+
+
+def make_report(old_path, new_path, out_file, header=None):
+    new_commit, new_df = load_stats(new_path)
+
+    # No baseline available (e.g. the first PR introducing benchmarks, or a run on
+    # a base commit that predates the suite). Report HEAD-only numbers and pass.
+    if not os.path.exists(old_path) or os.path.getsize(old_path) == 0:
+        df = new_df.rename(columns={"mean": f"Mean (s) HEAD {new_commit}"})
+        df[f"Mean (s) HEAD {new_commit}"] = df[f"Mean (s) HEAD {new_commit}"].map(
+            "{:.5f}".format
+        )
+        report = df.to_markdown(index=False)
+        note = "_No baseline found; showing HEAD results only (no comparison)._"
+        report = f"{note}\n\n{report}"
+        if header:
+            report = f"## {header}\n\n{report}"
+        _write(out_file, report)
+        return
+
+    old_commit, old_df = load_stats(old_path)
+
+    # Merge on benchmark name
+    df = old_df.merge(new_df, on="Benchmark", suffixes=("_old", "_new"))
+    old = (old_commit,)
+    new = (new_commit,)
+
+    pct_change = 100 * (df["mean_new"] - df["mean_old"]) / df["mean_old"]
+    df["Percent Change"] = pct_change.map("{:+.2f}".format)
+
+    # Format runtimes
+    df["mean_old"] = df["mean_old"].map("{:.5f}".format)
+    df["mean_new"] = df["mean_new"].map("{:.5f}".format)
+
+    # Change column names to commit ids
+    df = df.rename(
+        columns={
+            "mean_new": f"Mean (s) HEAD {new[0]}",
+            "mean_old": f"Mean (s) BASE {old[0]}",
+        }
+    )
+
+    report = df.to_markdown(index=False)
+    if header:
+        report = f"## {header}\n\n{report}"
+
+    with open(out_file, "w") as f:
+        f.write(report)
+
+    # Print report to logs
+    print(report)  # noqa: T201
+
+    # Fail if any benchmark regressed beyond threshold
+    if (pct_change > REGRESSION_THRESHOLD).any():
+        print(  # noqa: T201
+            f"\nFAILED: Regression exceeds {REGRESSION_THRESHOLD}% threshold"
+        )
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    header = sys.argv[4] if len(sys.argv) > 4 else None
+    make_report(sys.argv[1], sys.argv[2], sys.argv[3], header)

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,106 @@
+name: benchmarks
+
+on:
+  pull_request: {}
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# Needed for peter-evans/commit-comment to post the benchmark report on the commit.
+permissions:
+  contents: write
+
+jobs:
+  benchmark:
+    name: Benchmark (${{ matrix.platform }})
+    runs-on: ${{ matrix.platform }}
+    if: github.event_name == 'pull_request'
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [ubuntu-latest, macos-latest, windows-latest]
+    env:
+      # disable resyncing on uv run so `git checkout <base>` keeps the head-synced env
+      UV_NO_SYNC: "1"
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 50
+      - uses: tlambert03/setup-qt-libs@v1
+
+      - name: Set up Python
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.13"
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --no-dev --group testing
+
+      - name: Set Windows resolution
+        if: runner.os == 'Windows'
+        run: Set-DisplayResolution -Width 1920 -Height 1080 -Force
+        shell: powershell
+
+      - name: Install Windows OpenGL
+        if: runner.os == 'Windows'
+        run: |
+          git clone --depth 1 https://github.com/pyvista/gl-ci-helpers.git
+          powershell gl-ci-helpers/appveyor/install_opengl.ps1
+          if (Test-Path -Path "C:\Windows\system32\opengl32.dll" -PathType Leaf) {Exit 0} else {Exit 1}
+        shell: powershell
+
+      - name: Retrieve cached baseline if available
+        uses: actions/cache/restore@v5
+        id: cache_baseline
+        with:
+          path: baseline.json
+          key: benchmark-${{ matrix.platform }}-${{ github.event.pull_request.base.sha }}
+
+      # The benchmark suite lives under tests/benchmarks, which the default pytest
+      # config ignores; `-o addopts=` clears that so it is collected here. The GUI
+      # benchmarks need a real GL context, hence aganders3/headless-gui.
+      # Tolerant on purpose: the base commit may predate the benchmark suite (e.g.
+      # the first PR that introduces it), in which case there is no baseline to
+      # produce. The report step then falls back to HEAD-only numbers.
+      - name: Run baseline benchmark if not in cache
+        if: steps.cache_baseline.outputs.cache-hit != 'true'
+        continue-on-error: true
+        uses: aganders3/headless-gui@v2
+        with:
+          run: |
+            git checkout ${{ github.event.pull_request.base.sha }}
+            uv run pytest tests/benchmarks -o addopts= --benchmark-json baseline.json
+
+      - name: Cache baseline results
+        uses: actions/cache/save@v5
+        if: steps.cache_baseline.outputs.cache-hit != 'true' && hashFiles('baseline.json') != ''
+        with:
+          path: baseline.json
+          key: benchmark-${{ matrix.platform }}-${{ github.event.pull_request.base.sha }}
+
+      - name: Run benchmark on PR head
+        uses: aganders3/headless-gui@v2
+        with:
+          run: |
+            git checkout ${{ github.event.pull_request.head.sha }}
+            uv run pytest tests/benchmarks -o addopts= --benchmark-json pr.json
+
+      - name: Generate report
+        id: report
+        run: |
+          uv run --with pandas --with tabulate python .github/workflows/benchmark_pr.py baseline.json pr.json report.md "Benchmark: ${{ matrix.platform }}"
+        continue-on-error: true
+
+      - name: Comment on commit with report
+        uses: peter-evans/commit-comment@v3
+        if: github.event.pull_request.head.repo.fork == false
+        with:
+          body-path: report.md
+
+      - name: Fail if regression detected
+        if: steps.report.outcome == 'failure'
+        run: exit 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ testing =[
     "pytest>=8.3,<9",
     "pytest-cov>=6",
     "pytest-qt>=4.4,<5",
+    "pytest-benchmark>=5,<6",
 ]
 docs = [
     "myst-parser>=4,<5",
@@ -101,6 +102,12 @@ conflicts = [
 ]
 
 [tool.pytest.ini_options]
+# Benchmarks are slow and run in a dedicated CI job; exclude them from the normal
+# test suite (`just test` / `pytest .`). Run with `pytest tests/benchmarks -o addopts=`.
+addopts = "--ignore=tests/benchmarks"
+# Benchmark modules are named bench_*.py; collect those in addition to test_*.py so
+# that pointing pytest at the tests/benchmarks directory discovers them.
+python_files = ["test_*.py", "bench_*.py"]
 filterwarnings = [
     "error::DeprecationWarning:funtracks",
 ]

--- a/tests/benchmarks/bench_data_model.py
+++ b/tests/benchmarks/bench_data_model.py
@@ -1,0 +1,32 @@
+"""Data-model benchmarks (no napari GUI required).
+
+These exercise motile_tracker's own pure hot paths, so they run without a display.
+``extract_sorted_tracks`` is the O(N)+topological-sort routine behind every
+tree-view refresh.
+
+(SolutionTracks construction is intentionally *not* benchmarked here -- it is
+funtracks' code and is covered by funtracks' own benchmark suite.)
+"""
+
+from __future__ import annotations
+
+import napari
+
+from motile_tracker.data_views.views.tree_view.tree_widget_utils import (
+    extract_sorted_tracks,
+)
+
+
+def _colormap():
+    # Same colormap TracksViewer builds (tracks_viewer.py).
+    return napari.utils.colormaps.label_colormap(49, seed=0.5, background_value=0)
+
+
+def test_extract_sorted_tracks(benchmark, shared_tracks):
+    """Build the sorted-tracks dataframe that drives the tree view."""
+    cmap = _colormap()
+    benchmark.pedantic(
+        lambda: extract_sorted_tracks(shared_tracks, cmap),
+        rounds=3,
+        iterations=1,
+    )

--- a/tests/benchmarks/bench_ui_actions.py
+++ b/tests/benchmarks/bench_ui_actions.py
@@ -1,0 +1,200 @@
+"""UI action benchmarks (require a napari GUI / display).
+
+Cover the common interactive actions at scale: loading, selection, display-mode
+switching, tree-view rendering, and editing. Each benchmark builds its own app in
+``setup`` (not timed) and measures a single action with
+``benchmark.pedantic(..., rounds=1, iterations=1)`` -- the actions trigger a full
+refresh cascade that can take seconds at scale, so repeated rounds are impractical.
+
+In CI these run under aganders3/headless-gui (Xvfb-backed GL). They will segfault
+under the ``offscreen`` Qt platform, which lacks a real GL context.
+"""
+
+from __future__ import annotations
+
+from synthetic_data import pick_nodes
+
+# ----------------------------------------------------------------------------------
+# Loading
+# ----------------------------------------------------------------------------------
+
+
+def test_add_tracks(benchmark, make_napari_viewer, shared_tracks):
+    """Open viewer + add tracks (creates points/graph/labels layers + tree data)."""
+    from motile_tracker.application_menus import StartupWidget
+    from motile_tracker.data_views.views_coordinator.tracks_viewer import TracksViewer
+
+    def setup():
+        viewer = make_napari_viewer()
+        StartupWidget(viewer, mode="editing")
+        tv = TracksViewer.get_instance(viewer)
+        return (tv, shared_tracks), {}
+
+    benchmark.pedantic(
+        lambda tv, tracks: tv.tracks_list.add_tracks(tracks, "synthetic"),
+        setup=setup,
+        rounds=1,
+        iterations=1,
+    )
+
+
+# ----------------------------------------------------------------------------------
+# Selection / interaction (read-only w.r.t. the graph)
+# ----------------------------------------------------------------------------------
+
+
+def test_click_node_treeview(benchmark, build_app, shared_tracks):
+    def setup():
+        _, _, tree = build_app(shared_tracks)
+        return (tree, pick_nodes(shared_tracks)["tree_node"]), {}
+
+    benchmark.pedantic(
+        lambda tree, node: tree.tree_widget.node_clicked.emit(node, False),
+        setup=setup,
+        rounds=1,
+        iterations=1,
+    )
+
+
+def test_click_node_canvas(benchmark, build_app, shared_tracks):
+    def setup():
+        _, tv, _ = build_app(shared_tracks)
+        return (tv, pick_nodes(shared_tracks)["canvas_node"]), {}
+
+    benchmark.pedantic(
+        lambda tv, node: tv.selected_nodes.add(node, False),
+        setup=setup,
+        rounds=1,
+        iterations=1,
+    )
+
+
+def test_set_display_mode_lineage(benchmark, build_app, shared_tracks):
+    """Toggle to lineage mode with a node selected (filter + extract_lineage + update)."""
+
+    def setup():
+        _, tv, _ = build_app(shared_tracks)
+        tv.selected_nodes.reset()
+        tv.selected_nodes.add(pick_nodes(shared_tracks)["canvas_node"], False)
+        return (tv,), {}
+
+    benchmark.pedantic(
+        lambda tv: tv.set_display_mode("lineage"),
+        setup=setup,
+        rounds=1,
+        iterations=1,
+    )
+
+
+# ----------------------------------------------------------------------------------
+# Tree view rendering (read-only)
+# ----------------------------------------------------------------------------------
+
+
+def test_tree_flip_axes(benchmark, build_app, shared_tracks):
+    def setup():
+        _, _, tree = build_app(shared_tracks)
+        return (tree,), {}
+
+    benchmark.pedantic(
+        lambda tree: tree.flip_axes(), setup=setup, rounds=1, iterations=1
+    )
+
+
+def test_tree_feature_recolor(benchmark, build_app, shared_tracks):
+    """Switch tree coloring to a feature (full pyqtgraph redraw)."""
+
+    def setup():
+        _, _, tree = build_app(shared_tracks)
+        return (tree,), {}
+
+    benchmark.pedantic(
+        lambda tree: tree.toggle_feature_mode(),
+        setup=setup,
+        rounds=1,
+        iterations=1,
+    )
+
+
+def test_label_colormap_rebuild(benchmark, build_app, shared_tracks):
+    """Rebuild the DirectLabelColormap for the segmentation layer."""
+
+    def setup():
+        _, tv, _ = build_app(shared_tracks)
+        return (tv.tracking_layers.seg_layer,), {}
+
+    benchmark.pedantic(
+        lambda seg: seg._get_colormap(),
+        setup=setup,
+        rounds=3,
+        iterations=1,
+    )
+
+
+# ----------------------------------------------------------------------------------
+# Editing (mutating -> fresh_tracks each time)
+# ----------------------------------------------------------------------------------
+
+
+def test_delete_node(benchmark, build_app, fresh_tracks):
+    def setup():
+        _, tv, _ = build_app(fresh_tracks)
+        tv.selected_nodes.reset()
+        tv.selected_nodes.add(pick_nodes(fresh_tracks)["del_node"], False)
+        return (tv,), {}
+
+    benchmark.pedantic(lambda tv: tv.delete_node(), setup=setup, rounds=1, iterations=1)
+
+
+def test_delete_edge(benchmark, build_app, fresh_tracks):
+    def setup():
+        _, tv, _ = build_app(fresh_tracks)
+        u, v = pick_nodes(fresh_tracks)["del_edge"]
+        tv.selected_nodes.reset()
+        tv.selected_nodes.add(u, False)
+        tv.selected_nodes.add(v, True)
+        return (tv,), {}
+
+    benchmark.pedantic(lambda tv: tv.delete_edge(), setup=setup, rounds=1, iterations=1)
+
+
+def test_create_edge(benchmark, build_app, fresh_tracks):
+    """Recreate an edge that was just broken (guaranteed-valid, no force dialog)."""
+
+    def setup():
+        _, tv, _ = build_app(fresh_tracks)
+        u, v = pick_nodes(fresh_tracks)["del_edge"]
+        # Break the edge first so re-adding it is a valid action.
+        tv.selected_nodes.reset()
+        tv.selected_nodes.add(u, False)
+        tv.selected_nodes.add(v, True)
+        tv.delete_edge()
+        tv.selected_nodes.reset()
+        tv.selected_nodes.add(u, False)
+        tv.selected_nodes.add(v, True)
+        return (tv,), {}
+
+    benchmark.pedantic(lambda tv: tv.create_edge(), setup=setup, rounds=1, iterations=1)
+
+
+def test_undo(benchmark, build_app, fresh_tracks):
+    def setup():
+        _, tv, _ = build_app(fresh_tracks)
+        tv.selected_nodes.reset()
+        tv.selected_nodes.add(pick_nodes(fresh_tracks)["del_node"], False)
+        tv.delete_node()
+        return (tv,), {}
+
+    benchmark.pedantic(lambda tv: tv.undo(), setup=setup, rounds=1, iterations=1)
+
+
+def test_redo(benchmark, build_app, fresh_tracks):
+    def setup():
+        _, tv, _ = build_app(fresh_tracks)
+        tv.selected_nodes.reset()
+        tv.selected_nodes.add(pick_nodes(fresh_tracks)["del_node"], False)
+        tv.delete_node()
+        tv.undo()
+        return (tv,), {}
+
+    benchmark.pedantic(lambda tv: tv.redo(), setup=setup, rounds=1, iterations=1)

--- a/tests/benchmarks/bench_ui_actions.py
+++ b/tests/benchmarks/bench_ui_actions.py
@@ -12,7 +12,7 @@ under the ``offscreen`` Qt platform, which lacks a real GL context.
 
 from __future__ import annotations
 
-from synthetic_data import pick_nodes
+from synthetic_data import pick_nodes, tracklet_nodes
 
 # ----------------------------------------------------------------------------------
 # Loading
@@ -144,6 +144,38 @@ def test_delete_node(benchmark, build_app, fresh_tracks):
         return (tv,), {}
 
     benchmark.pedantic(lambda tv: tv.delete_node(), setup=setup, rounds=1, iterations=1)
+
+
+def test_delete_nodes_bulk(benchmark, build_app, fresh_tracks):
+    """Delete a whole tracklet (many nodes) in a single action.
+
+    Exercises the multi-node UserDeleteNodes path. Since the refresh runs once
+    regardless of count, this vs test_delete_node shows fixed-refresh overhead vs
+    marginal per-node cost, and catches a regression to refresh-per-node.
+    """
+
+    def setup():
+        _, tv, _ = build_app(fresh_tracks)
+        nodes = tracklet_nodes(fresh_tracks, pick_nodes(fresh_tracks)["del_node"])
+        tv.selected_nodes.reset()
+        tv.selected_nodes.add_list(nodes)
+        return (tv,), {}
+
+    benchmark.pedantic(lambda tv: tv.delete_node(), setup=setup, rounds=1, iterations=1)
+
+
+def test_undo_bulk_delete(benchmark, build_app, fresh_tracks):
+    """Undo a bulk (whole-tracklet) delete -- restores many nodes in one action."""
+
+    def setup():
+        _, tv, _ = build_app(fresh_tracks)
+        nodes = tracklet_nodes(fresh_tracks, pick_nodes(fresh_tracks)["del_node"])
+        tv.selected_nodes.reset()
+        tv.selected_nodes.add_list(nodes)
+        tv.delete_node()
+        return (tv,), {}
+
+    benchmark.pedantic(lambda tv: tv.undo(), setup=setup, rounds=1, iterations=1)
 
 
 def test_delete_edge(benchmark, build_app, fresh_tracks):

--- a/tests/benchmarks/conftest.py
+++ b/tests/benchmarks/conftest.py
@@ -18,13 +18,17 @@ from motile_tracker.application_menus import StartupWidget
 from motile_tracker.data_views import TreeWidget
 from motile_tracker.data_views.views_coordinator.tracks_viewer import TracksViewer
 
-# Preset selectable via env var for quick local runs, e.g. MT_BENCH_PRESET=small.
-BENCH_PARAMS = PRESETS[os.environ.get("MT_BENCH_PRESET", "large")]
+# By default the suite sweeps these sizes so each action yields a scaling series
+# (e.g. test_delete_node[small], test_delete_node[large]). Set MT_BENCH_PRESET to a
+# single preset name (small/large/xlarge/large_2d) to pin one size for a quick local run.
+DEFAULT_SWEEP = ["small", "large"]
+_env_preset = os.environ.get("MT_BENCH_PRESET")
+SWEEP = [_env_preset] if _env_preset else DEFAULT_SWEEP
 
 
-@pytest.fixture(scope="session")
-def bench_params():
-    return BENCH_PARAMS
+@pytest.fixture(scope="session", params=SWEEP)
+def bench_params(request):
+    return PRESETS[request.param]
 
 
 @pytest.fixture(scope="session")

--- a/tests/benchmarks/conftest.py
+++ b/tests/benchmarks/conftest.py
@@ -1,0 +1,57 @@
+"""Fixtures for the benchmark suite.
+
+Runs under pytest's default (prepend) import mode, which puts this directory on
+sys.path, so ``synthetic_data`` is importable by bare name here and in the bench
+modules. The parent ``tests/conftest.py`` autouse ``reset_tracks_viewer`` fixture
+clears the TracksViewer singleton around every test, so each benchmark builds its
+own viewer/app; mutating benchmarks additionally use freshly-generated tracks.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from synthetic_data import PRESETS, generate_synthetic_tracks
+
+from motile_tracker.application_menus import StartupWidget
+from motile_tracker.data_views import TreeWidget
+from motile_tracker.data_views.views_coordinator.tracks_viewer import TracksViewer
+
+# Preset selectable via env var for quick local runs, e.g. MT_BENCH_PRESET=small.
+BENCH_PARAMS = PRESETS[os.environ.get("MT_BENCH_PRESET", "large")]
+
+
+@pytest.fixture(scope="session")
+def bench_params():
+    return BENCH_PARAMS
+
+
+@pytest.fixture(scope="session")
+def shared_tracks(bench_params):
+    """Session-scoped tracks for READ-ONLY benchmarks (never mutate these)."""
+    return generate_synthetic_tracks(bench_params)
+
+
+@pytest.fixture
+def fresh_tracks(bench_params):
+    """Freshly-generated tracks for MUTATING benchmarks (delete/add/undo/redo)."""
+    return generate_synthetic_tracks(bench_params)
+
+
+@pytest.fixture
+def build_app(make_napari_viewer):
+    """Return a builder: tracks -> (viewer, tracks_viewer, tree_widget).
+
+    Uses make_napari_viewer so the viewer is torn down by napari's fixture.
+    """
+
+    def _build(tracks):
+        viewer = make_napari_viewer()
+        StartupWidget(viewer, mode="editing")
+        tv = TracksViewer.get_instance(viewer)
+        tv.tracks_list.add_tracks(tracks, "synthetic")
+        tree_widget = viewer.window._qt_window.findChild(TreeWidget)
+        return viewer, tv, tree_widget
+
+    return _build

--- a/tests/benchmarks/synthetic_data.py
+++ b/tests/benchmarks/synthetic_data.py
@@ -1,0 +1,297 @@
+"""Synthetic "large" tracking dataset generator for benchmarks.
+
+Builds a :class:`funtracks.data_model.SolutionTracks` of dividing spheres directly
+as an in-memory tracksdata graph, following the same construction pattern used in
+``tests/conftest.py``. Masks and bounding boxes live on the graph nodes, so the
+segmentation is exposed lazily as a ``td.array.GraphArrayView`` (exactly the
+real-app path) -- no dense segmentation array is ever materialized. This means
+``frame_shape`` can be realistically large at negligible cost; only the per-node
+sphere masks consume memory.
+
+The generator is deterministic given ``seed`` so benchmark timings are comparable
+across runs and platforms.
+
+Run directly to print dataset statistics and build time::
+
+    python tests/benchmarks/synthetic_data.py
+    python tests/benchmarks/synthetic_data.py --preset small
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import tracksdata as td
+from funtracks.data_model import SolutionTracks
+from funtracks.utils.tracksdata_utils import create_empty_graphview_graph
+from tracksdata.nodes._mask import Mask
+
+# Node attributes mirror tests/conftest.py. The TrackAnnotator inside SolutionTracks
+# recomputes tracklet_id / lineage_id from graph topology, so track_id / lineage_id
+# here are informational; edges are the source of truth for divisions.
+_NODE_ATTRS = [
+    "pos",
+    "area",
+    "track_id",
+    "lineage_id",
+    td.DEFAULT_ATTR_KEYS.MASK,
+    td.DEFAULT_ATTR_KEYS.BBOX,
+]
+
+
+@dataclass(frozen=True)
+class SyntheticParams:
+    """Parameters controlling the synthetic dataset size and shape."""
+
+    n_frames: int
+    n_start_cells: int
+    division_prob: float  # per-cell, per-frame probability of dividing
+    frame_shape: tuple[int, ...]  # spatial shape (2D: (y, x); 3D: (z, y, x))
+    radius: int
+    max_cells: int  # cap on simultaneously active cells (bounds exponential growth)
+    step_std: float = 3.0  # random-walk std per frame (pixels)
+    seed: int = 42
+
+    @property
+    def ndim(self) -> int:
+        """Number of dimensions including time (2D+t -> 3, 3D+t -> 4)."""
+        return len(self.frame_shape) + 1
+
+
+# Default benchmark size: ~14k nodes / ~100 divisions over 100 frames at a large
+# spatial scale (lazy segmentation makes the big frame free).
+# Tuned so the heaviest single measured op (delete + full refresh) is ~5s, keeping
+# the whole suite practical to run repeatedly across three CI platforms.
+LARGE = SyntheticParams(
+    n_frames=100,
+    n_start_cells=80,
+    division_prob=0.01,
+    frame_shape=(64, 512, 512),
+    radius=6,
+    max_cells=250,
+)
+
+# Opt-in stress size (~59k nodes). Heavy ops take tens of seconds; use locally, not CI.
+XLARGE = SyntheticParams(
+    n_frames=200,
+    n_start_cells=150,
+    division_prob=0.006,
+    frame_shape=(64, 512, 512),
+    radius=6,
+    max_cells=600,
+)
+
+# Small preset for fast local iteration.
+SMALL = SyntheticParams(
+    n_frames=20,
+    n_start_cells=15,
+    division_prob=0.02,
+    frame_shape=(32, 128, 128),
+    radius=5,
+    max_cells=60,
+)
+
+# 2D+time large preset (UI paths differ between 2D and 3D).
+LARGE_2D = SyntheticParams(
+    n_frames=100,
+    n_start_cells=80,
+    division_prob=0.01,
+    frame_shape=(1024, 1024),
+    radius=8,
+    max_cells=250,
+)
+
+PRESETS = {"large": LARGE, "xlarge": XLARGE, "small": SMALL, "large_2d": LARGE_2D}
+
+
+def _sphere_mask(radius: int, spatial_ndim: int) -> np.ndarray:
+    """Boolean sphere mask of the given radius in an (2r+1)^ndim box."""
+    size = 2 * radius + 1
+    coords = np.ogrid[tuple(slice(0, size) for _ in range(spatial_ndim))]
+    dist_sq = sum((c - radius) ** 2 for c in coords)
+    return dist_sq <= radius**2
+
+
+def _bbox_and_mask(
+    center: np.ndarray, radius: int, frame_shape: tuple[int, ...]
+) -> tuple[np.ndarray, Mask]:
+    """Build a clamped bbox and cropped sphere Mask for a cell centered at ``center``.
+
+    bbox layout matches tracksdata: [d0_0, d1_0, ..., d0_1, d1_1, ...] (starts then
+    stops), e.g. 2D -> [y0, x0, y1, x1], 3D -> [z0, y0, x0, z1, y1, x1].
+    """
+    spatial_ndim = len(frame_shape)
+    full = _sphere_mask(radius, spatial_ndim)
+    starts, stops, crops = [], [], []
+    for axis in range(spatial_ndim):
+        lo = int(round(center[axis])) - radius
+        hi = lo + 2 * radius + 1
+        clo, chi = max(lo, 0), min(hi, frame_shape[axis])
+        starts.append(clo)
+        stops.append(chi)
+        crops.append(slice(clo - lo, (2 * radius + 1) - (hi - chi)))
+    mask_arr = np.ascontiguousarray(full[tuple(crops)])
+    bbox = np.array(starts + stops, dtype=np.int64)
+    return bbox, Mask(mask_arr, bbox=bbox)
+
+
+def build_graph(params: SyntheticParams = LARGE) -> td.graph.GraphView:
+    """Build the raw tracksdata GraphView of dividing spheres (no SolutionTracks wrap).
+
+    Exposed separately so benchmarks can time ``SolutionTracks`` construction on a
+    freshly-built graph.
+    """
+    rng = np.random.default_rng(params.seed)
+    spatial_ndim = len(params.frame_shape)
+    shape = np.array(params.frame_shape, dtype=float)
+
+    graph = create_empty_graphview_graph(
+        node_attributes=_NODE_ATTRS,
+        edge_attributes=["iou"],
+        ndim=params.ndim,
+    )
+
+    nodes: list[dict] = []
+    indices: list[int] = []
+    edges: list[dict] = []
+
+    next_node_id = 1
+    next_track_id = 1
+    next_lineage_id = 1
+
+    def add_node(t: int, pos: np.ndarray, track_id: int, lineage_id: int) -> int:
+        nonlocal next_node_id
+        bbox, mask = _bbox_and_mask(pos, params.radius, params.frame_shape)
+        node_id = next_node_id
+        next_node_id += 1
+        nodes.append(
+            {
+                "t": t,
+                "pos": [float(x) for x in pos],
+                "area": float(mask.mask.sum()),
+                "track_id": track_id,
+                "lineage_id": lineage_id,
+                "solution": True,
+                td.DEFAULT_ATTR_KEYS.MASK: mask,
+                td.DEFAULT_ATTR_KEYS.BBOX: bbox,
+            }
+        )
+        indices.append(node_id)
+        return node_id
+
+    # Active cells: each is (last_node_id, pos, track_id, lineage_id).
+    active: list[tuple[int, np.ndarray, int, int]] = []
+    margin = params.radius + 1
+    for _ in range(params.n_start_cells):
+        pos = rng.uniform(margin, shape - margin)
+        node_id = add_node(0, pos, next_track_id, next_lineage_id)
+        active.append((node_id, pos, next_track_id, next_lineage_id))
+        next_track_id += 1
+        next_lineage_id += 1
+
+    for t in range(1, params.n_frames):
+        new_active: list[tuple[int, np.ndarray, int, int]] = []
+        for parent_id, pos, track_id, lineage_id in active:
+            step = rng.normal(0.0, params.step_std, size=spatial_ndim)
+            new_pos = np.clip(pos + step, margin, shape - margin)
+
+            can_divide = (
+                rng.random() < params.division_prob
+                and len(active) + len(new_active) < params.max_cells
+            )
+            if can_divide:
+                for _ in range(2):
+                    offset = rng.normal(0.0, params.radius, size=spatial_ndim)
+                    child_pos = np.clip(new_pos + offset, margin, shape - margin)
+                    child_id = add_node(t, child_pos, next_track_id, lineage_id)
+                    edges.append(
+                        {
+                            "source_id": parent_id,
+                            "target_id": child_id,
+                            "iou": 0.0,
+                            "solution": True,
+                        }
+                    )
+                    new_active.append((child_id, child_pos, next_track_id, lineage_id))
+                    next_track_id += 1
+            else:
+                child_id = add_node(t, new_pos, track_id, lineage_id)
+                edges.append(
+                    {
+                        "source_id": parent_id,
+                        "target_id": child_id,
+                        "iou": 0.5,
+                        "solution": True,
+                    }
+                )
+                new_active.append((child_id, new_pos, track_id, lineage_id))
+        active = new_active
+
+    graph.bulk_add_nodes(nodes=nodes, indices=indices)
+    graph.bulk_add_edges(edges)
+    graph._update_metadata(segmentation_shape=(params.n_frames, *params.frame_shape))
+    return graph
+
+
+def generate_synthetic_tracks(params: SyntheticParams = LARGE) -> SolutionTracks:
+    """Generate a SolutionTracks of dividing spheres from ``params``.
+
+    Returns a fully-constructed SolutionTracks whose ``.segmentation`` is a lazy
+    GraphArrayView backed by the per-node masks.
+    """
+    graph = build_graph(params)
+    return SolutionTracks(graph=graph, ndim=params.ndim, time_attr="t")
+
+
+def pick_nodes(tracks: SolutionTracks) -> dict:
+    """Pick deterministic, distinct nodes/edges to act on."""
+    edges = tracks.graph.edge_attrs(
+        attr_keys=[td.DEFAULT_ATTR_KEYS.EDGE_SOURCE, td.DEFAULT_ATTR_KEYS.EDGE_TARGET]
+    )
+    src = edges[td.DEFAULT_ATTR_KEYS.EDGE_SOURCE].to_list()
+    tgt = edges[td.DEFAULT_ATTR_KEYS.EDGE_TARGET].to_list()
+    return {
+        "tree_node": int(src[0]),
+        "canvas_node": int(src[len(src) // 3]),
+        "del_node": int(src[len(src) // 2]),
+        "del_edge": (int(src[-1]), int(tgt[-1])),
+    }
+
+
+def _describe(tracks: SolutionTracks) -> dict:
+    graph = tracks.graph
+    src = graph.edge_attrs(attr_keys=[td.DEFAULT_ATTR_KEYS.EDGE_SOURCE])[
+        td.DEFAULT_ATTR_KEYS.EDGE_SOURCE
+    ].to_list()
+    # A division = a source node appearing in more than one edge.
+    counts: dict[int, int] = {}
+    for s in src:
+        counts[s] = counts.get(s, 0) + 1
+    n_divisions = sum(1 for c in counts.values() if c > 1)
+    return {
+        "n_nodes": graph.num_nodes(),
+        "n_edges": graph.num_edges(),
+        "n_divisions": n_divisions,
+    }
+
+
+if __name__ == "__main__":
+    import argparse
+    import time
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--preset", choices=PRESETS, default="large")
+    args = parser.parse_args()
+
+    params = PRESETS[args.preset]
+    t0 = time.perf_counter()
+    tracks = generate_synthetic_tracks(params)
+    build_s = time.perf_counter() - t0
+    stats = _describe(tracks)
+    print(f"preset={args.preset} ndim={params.ndim} frame_shape={params.frame_shape}")  # noqa: T201
+    print(  # noqa: T201
+        f"nodes={stats['n_nodes']} edges={stats['n_edges']} "
+        f"divisions={stats['n_divisions']} build={build_s:.2f}s"
+    )
+    print(f"segmentation (lazy) shape={tracks.segmentation.shape}")  # noqa: T201

--- a/tests/benchmarks/synthetic_data.py
+++ b/tests/benchmarks/synthetic_data.py
@@ -259,6 +259,12 @@ def pick_nodes(tracks: SolutionTracks) -> dict:
     }
 
 
+def tracklet_nodes(tracks: SolutionTracks, node: int) -> list[int]:
+    """All node ids sharing the tracklet (track_id) of ``node`` -- a connected path."""
+    tid = tracks.get_track_id(node)
+    return [int(n) for n in tracks.graph.node_ids() if tracks.get_track_id(n) == tid]
+
+
 def _describe(tracks: SolutionTracks) -> dict:
     graph = tracks.graph
     src = graph.edge_attrs(attr_keys=[td.DEFAULT_ATTR_KEYS.EDGE_SOURCE])[


### PR DESCRIPTION
Similar to funtracks, I add a set of benchmarks (mostly UI) that run automatically via github ci. The benchmark results can be seen: 
- as comments to the commits
- on the "funkelab.github.io/motile_tracker/benchmarks/" page

The benchmark code generates synthetic datasets (from small to big) to test the UI actions on. Via cli, the user can pick the synthetic dataset to use. By default, the github ci picks two sizes (`small` and `large`)

In order to see results, we will first have to merge this branch into main, otherwise there is nothing to compare to, and the benchmarks will silently not run/report