### PR TITLE
mask conversion UI dialog (uint64 to bool)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,8 +31,6 @@ classifiers = [
 
 dependencies =[
     "napari>=0.6.2,<0.8.0",
-    # 2.0.4 fixes the in-place Mask.__isub__ misuse on erase, which corrupts the
-    # GraphArrayView cache with tracksdata >=0.1.0rc7 (funtracks#264)
     "funtracks>=2.0.4,<3",
     "appdirs>=1,<2",
     "numpy>=2,<3",
@@ -101,13 +99,6 @@ conflicts = [
         {extra = "gurobi12"},
         {extra = "gurobi13"},
     ],
-]
-# TEMPORARY: the geff mask dtype helpers used by the geff import dialog
-# (convert_geff_prop_dtype / geff_prop_dtype, royerlab/tracksdata#319) are only on
-# tracksdata main. funtracks pins tracksdata exactly, so override it to test against
-# the real code. Remove once a tracksdata release includes them.
-override-dependencies = [
-    "tracksdata[spatial] @ git+https://github.com/royerlab/tracksdata@80d94cc7da0ce063d2fa2a3b18271606294cbb27",
 ]
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,9 @@ classifiers = [
 
 dependencies =[
     "napari>=0.6.2,<0.8.0",
-    "funtracks>=2,<3",
+    # 2.0.4 fixes the in-place Mask.__isub__ misuse on erase, which corrupts the
+    # GraphArrayView cache with tracksdata >=0.1.0rc7 (funtracks#264)
+    "funtracks>=2.0.4,<3",
     "appdirs>=1,<2",
     "numpy>=2,<3",
     "magicgui>=0.10.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,13 @@ conflicts = [
         {extra = "gurobi13"},
     ],
 ]
+# TEMPORARY: the geff mask dtype helpers used by the geff import dialog
+# (convert_geff_prop_dtype / geff_prop_dtype, royerlab/tracksdata#319) are only on
+# tracksdata main. funtracks pins tracksdata exactly, so override it to test against
+# the real code. Remove once a tracksdata release includes them.
+override-dependencies = [
+    "tracksdata[spatial] @ git+https://github.com/royerlab/tracksdata@80d94cc7da0ce063d2fa2a3b18271606294cbb27",
+]
 
 [tool.pytest.ini_options]
 # Benchmarks are slow and run in a dedicated CI job; exclude them from the normal

--- a/src/motile_tracker/import_export/menus/import_dialog.py
+++ b/src/motile_tracker/import_export/menus/import_dialog.py
@@ -329,52 +329,64 @@ class ImportDialog(QDialog):
             recompute = "area" not in self.tracks.graph.node_attr_keys()
             self.tracks.enable_features(["area"], recompute=recompute)
 
-    def _maybe_convert_legacy_masks(self, geff_dir: Path) -> bool:
+    def _maybe_convert_legacy_masks(self, geff_dir: Path) -> Path | None:
         """Offer to convert masks stored in an older, memory-heavy dtype.
 
         Geff files written by older versions of tracksdata store segmentation
-        masks as ``uint64`` rather than ``bool``, which uses ~8x more memory
-        when read and can cause out-of-memory errors. If such masks are
-        detected, warn the user and offer a lossless, in-place conversion.
+        masks as integers (e.g. ``uint64``) rather than ``bool``, using ~8x more
+        memory when read. If such masks are detected, warn the user and offer a
+        lossless conversion. To keep the original (possibly shared) file
+        untouched, the conversion is written to a ``*_bool.geff`` copy next to
+        it, and that copy is loaded instead.
 
         Returns:
-            bool: True to continue the import, False to abort.
+            Path | None: the geff directory to import (the original, or the
+            converted copy), or None if the user cancelled.
         """
         try:
-            from tracksdata.io import convert_geff_masks_to_bool, geff_mask_dtype
+            from tracksdata.io import convert_geff_mask_to_bool, geff_mask_dtype
         except ImportError:
-            return True  # older tracksdata without the utility; import as before
+            return geff_dir  # older tracksdata without the utility; import as before
 
         try:
             dtype = geff_mask_dtype(geff_dir)
         except Exception:  # noqa: BLE001
-            return True  # detection failed; don't block the import
+            return geff_dir  # detection failed; don't block the import
 
         if dtype is None or dtype == "bool":
-            return True
+            return geff_dir
 
         answer = QMessageBox.question(
             self,
             "Old mask format detected",
-            f"This geff stores segmentation masks as '{dtype}' (an older format).\n\n"
-            "Loading them as-is uses about 8x more memory and may run out of memory "
-            "on large datasets. Convert the masks to boolean now? This edits the file "
-            "in place and is lossless.",
+            f"This geff stores segmentation masks as '{dtype}', an older format that "
+            "uses about 8x more memory when loaded.\n\n"
+            "Convert them to boolean now? A converted copy will be written next to the "
+            "original, which is left untouched.",
             QMessageBox.Yes | QMessageBox.No | QMessageBox.Cancel,
             QMessageBox.Yes,
         )
         if answer == QMessageBox.Cancel:
-            return False
-        if answer == QMessageBox.Yes:
-            QApplication.setOverrideCursor(Qt.WaitCursor)
-            try:
-                convert_geff_masks_to_bool(geff_dir)
-            except Exception as e:  # noqa: BLE001
-                QMessageBox.critical(self, "Error", f"Failed to convert masks: {e}")
-                return False
-            finally:
-                QApplication.restoreOverrideCursor()
-        return True
+            return None
+        if answer == QMessageBox.No:
+            return geff_dir  # load the original as-is
+
+        name = geff_dir.name
+        out_name = (
+            f"{name[:-5]}_bool.geff" if name.endswith(".geff") else f"{name}_bool"
+        )
+        out_path = geff_dir.parent / out_name
+
+        QApplication.setOverrideCursor(Qt.WaitCursor)
+        try:
+            if not out_path.exists():
+                convert_geff_mask_to_bool(geff_dir, output_path=out_path)
+        except Exception as e:  # noqa: BLE001
+            QMessageBox.critical(self, "Error", f"Failed to convert masks: {e}")
+            return None
+        finally:
+            QApplication.restoreOverrideCursor()
+        return out_path
 
     def _finish(self) -> None:
         """Tries to read the csv/geff file and optional segmentation image and apply the
@@ -386,7 +398,8 @@ class ImportDialog(QDialog):
                 group_path = Path(self.import_widget.root.path)  # e.g. 'tracks'
                 geff_dir = store_path / group_path
 
-                if not self._maybe_convert_legacy_masks(geff_dir):
+                geff_dir = self._maybe_convert_legacy_masks(geff_dir)
+                if geff_dir is None:
                     return
 
                 self.name = self.import_widget.dir_name

--- a/src/motile_tracker/import_export/menus/import_dialog.py
+++ b/src/motile_tracker/import_export/menus/import_dialog.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import numpy as np
 from funtracks.import_export import import_from_geff, tracks_from_df
 from funtracks.import_export.magic_imread import magic_imread
 from geff_spec.utils import axes_from_lists
@@ -329,64 +330,61 @@ class ImportDialog(QDialog):
             recompute = "area" not in self.tracks.graph.node_attr_keys()
             self.tracks.enable_features(["area"], recompute=recompute)
 
-    def _maybe_convert_legacy_masks(self, geff_dir: Path) -> Path | None:
+    def _maybe_convert_legacy_masks(self, geff_dir: Path) -> bool:
         """Offer to convert masks stored in an older, memory-heavy dtype.
 
         Geff files written by older versions of tracksdata store segmentation
         masks as integers (e.g. ``uint64``) rather than ``bool``, using ~8x more
-        memory when read. If such masks are detected, warn the user and offer a
-        lossless conversion. To keep the original (possibly shared) file
-        untouched, the conversion is written to a ``*_bool.geff`` copy next to
-        it, and that copy is loaded instead.
+        memory when read, which can run out of memory on large datasets. If such
+        masks are detected, warn the user and offer a lossless, in-place
+        conversion of the mask buffer (the rest of the geff is untouched).
 
         Returns:
-            Path | None: the geff directory to import (the original, or the
-            converted copy), or None if the user cancelled.
+            bool: True to continue the import, False if the user cancelled or the
+            conversion failed.
         """
+        # TODO: the geff dtype helpers are only on tracksdata main
+        # (royerlab/tracksdata#319). Once released, add a tracksdata floor to
+        # pyproject.toml and import these at module level.
         try:
-            from tracksdata.io import convert_geff_mask_to_bool, geff_mask_dtype
+            from tracksdata.constants import DEFAULT_ATTR_KEYS
+            from tracksdata.io import convert_geff_prop_dtype, geff_prop_dtype
         except ImportError:
-            return geff_dir  # older tracksdata without the utility; import as before
+            return True  # older tracksdata without the utility; import as before
 
+        mask_key = DEFAULT_ATTR_KEYS.MASK
         try:
-            dtype = geff_mask_dtype(geff_dir)
+            dtype = geff_prop_dtype(geff_dir, mask_key)
         except Exception:  # noqa: BLE001
-            return geff_dir  # detection failed; don't block the import
+            return True  # detection failed; don't block the import
 
-        if dtype is None or dtype == "bool":
-            return geff_dir
+        if dtype is None or dtype == np.bool_:
+            return True
 
         answer = QMessageBox.question(
             self,
             "Old mask format detected",
             f"This geff stores segmentation masks as '{dtype}', an older format that "
             "uses about 8x more memory when loaded.\n\n"
-            "Convert them to boolean now? A converted copy will be written next to the "
-            "original, which is left untouched.",
+            "Convert them to boolean now? The conversion is lossless, but it edits "
+            f"{geff_dir.name} in place.",
             QMessageBox.Yes | QMessageBox.No | QMessageBox.Cancel,
             QMessageBox.Yes,
         )
         if answer == QMessageBox.Cancel:
-            return None
+            return False
         if answer == QMessageBox.No:
-            return geff_dir  # load the original as-is
-
-        name = geff_dir.name
-        out_name = (
-            f"{name[:-5]}_bool.geff" if name.endswith(".geff") else f"{name}_bool"
-        )
-        out_path = geff_dir.parent / out_name
+            return True  # load as-is
 
         QApplication.setOverrideCursor(Qt.WaitCursor)
         try:
-            if not out_path.exists():
-                convert_geff_mask_to_bool(geff_dir, output_path=out_path)
+            convert_geff_prop_dtype(geff_dir, mask_key, np.bool_)
         except Exception as e:  # noqa: BLE001
             QMessageBox.critical(self, "Error", f"Failed to convert masks: {e}")
-            return None
+            return False
         finally:
             QApplication.restoreOverrideCursor()
-        return out_path
+        return True
 
     def _finish(self) -> None:
         """Tries to read the csv/geff file and optional segmentation image and apply the
@@ -398,8 +396,7 @@ class ImportDialog(QDialog):
                 group_path = Path(self.import_widget.root.path)  # e.g. 'tracks'
                 geff_dir = store_path / group_path
 
-                geff_dir = self._maybe_convert_legacy_masks(geff_dir)
-                if geff_dir is None:
+                if not self._maybe_convert_legacy_masks(geff_dir):
                     return
 
                 self.name = self.import_widget.dir_name

--- a/src/motile_tracker/import_export/menus/import_dialog.py
+++ b/src/motile_tracker/import_export/menus/import_dialog.py
@@ -329,6 +329,53 @@ class ImportDialog(QDialog):
             recompute = "area" not in self.tracks.graph.node_attr_keys()
             self.tracks.enable_features(["area"], recompute=recompute)
 
+    def _maybe_convert_legacy_masks(self, geff_dir: Path) -> bool:
+        """Offer to convert masks stored in an older, memory-heavy dtype.
+
+        Geff files written by older versions of tracksdata store segmentation
+        masks as ``uint64`` rather than ``bool``, which uses ~8x more memory
+        when read and can cause out-of-memory errors. If such masks are
+        detected, warn the user and offer a lossless, in-place conversion.
+
+        Returns:
+            bool: True to continue the import, False to abort.
+        """
+        try:
+            from tracksdata.io import convert_geff_masks_to_bool, geff_mask_dtype
+        except ImportError:
+            return True  # older tracksdata without the utility; import as before
+
+        try:
+            dtype = geff_mask_dtype(geff_dir)
+        except Exception:  # noqa: BLE001
+            return True  # detection failed; don't block the import
+
+        if dtype is None or dtype == "bool":
+            return True
+
+        answer = QMessageBox.question(
+            self,
+            "Old mask format detected",
+            f"This geff stores segmentation masks as '{dtype}' (an older format).\n\n"
+            "Loading them as-is uses about 8x more memory and may run out of memory "
+            "on large datasets. Convert the masks to boolean now? This edits the file "
+            "in place and is lossless.",
+            QMessageBox.Yes | QMessageBox.No | QMessageBox.Cancel,
+            QMessageBox.Yes,
+        )
+        if answer == QMessageBox.Cancel:
+            return False
+        if answer == QMessageBox.Yes:
+            QApplication.setOverrideCursor(Qt.WaitCursor)
+            try:
+                convert_geff_masks_to_bool(geff_dir)
+            except Exception as e:  # noqa: BLE001
+                QMessageBox.critical(self, "Error", f"Failed to convert masks: {e}")
+                return False
+            finally:
+                QApplication.restoreOverrideCursor()
+        return True
+
     def _finish(self) -> None:
         """Tries to read the csv/geff file and optional segmentation image and apply the
         attribute to column mapping to construct a Tracks object"""
@@ -338,6 +385,9 @@ class ImportDialog(QDialog):
                 store_path = self.import_widget.store_path
                 group_path = Path(self.import_widget.root.path)  # e.g. 'tracks'
                 geff_dir = store_path / group_path
+
+                if not self._maybe_convert_legacy_masks(geff_dir):
+                    return
 
                 self.name = self.import_widget.dir_name
                 scale = self.scale_widget.get_scale() if self.seg else None

--- a/tests/import_export/test_import_dialog.py
+++ b/tests/import_export/test_import_dialog.py
@@ -877,3 +877,150 @@ def test_motile_run_load_backward_compat(tmp_path, graph_2d):
     assert loaded.run_name == "old_run"
     assert loaded.graph.num_nodes() == graph_2d.num_nodes()
     assert loaded.graph.num_edges() == graph_2d.num_edges()
+
+
+# --- legacy (non-bool) mask conversion -------------------------------------
+
+
+def _write_geff(tracks: Tracks, path: Path) -> Path:
+    """Export tracks to a geff and return the inner geff group directory."""
+    export_to_geff(tracks, path)
+    return path / "tracks.geff"
+
+
+@pytest.fixture
+def legacy_mask_geff(tmp_path, graph_2d) -> Path:
+    """A geff whose masks are stored as uint64, as older tracksdata wrote them."""
+    from tracksdata.io import convert_geff_prop_dtype, geff_prop_dtype
+
+    tracks = Tracks(graph_2d, ndim=3, time_attr="t", tracklet_attr="track_id")
+    geff_dir = _write_geff(tracks, tmp_path / "legacy.zarr")
+    convert_geff_prop_dtype(geff_dir, "mask", np.uint64)
+    assert geff_prop_dtype(geff_dir, "mask") == np.dtype(np.uint64)
+    return geff_dir
+
+
+def _mask_dtype(geff_dir: Path) -> np.dtype:
+    from tracksdata.io import geff_prop_dtype
+
+    return geff_prop_dtype(geff_dir, "mask")
+
+
+def test_legacy_masks_converted_in_place_on_yes(
+    qtbot, legacy_mask_geff, mock_qmessagebox
+):
+    """Answering Yes rewrites the mask buffer to bool in place, without a copy."""
+    dialog = ImportDialog(import_type="geff")
+    qtbot.addWidget(dialog)
+    mock_qmessagebox.question.return_value = mock_qmessagebox.Yes
+
+    assert dialog._maybe_convert_legacy_masks(legacy_mask_geff) is True
+
+    assert _mask_dtype(legacy_mask_geff) == np.dtype(bool)
+    # No duplicate geff written next to the original
+    siblings = [p.name for p in legacy_mask_geff.parent.glob("*.geff")]
+    assert siblings == [legacy_mask_geff.name]
+
+
+@pytest.mark.parametrize("answer_attr, expected", [("No", True), ("Cancel", False)])
+def test_legacy_masks_not_converted_on_no_or_cancel(
+    qtbot, legacy_mask_geff, mock_qmessagebox, answer_attr, expected
+):
+    """No imports the file as-is; Cancel aborts the import. Neither converts."""
+    dialog = ImportDialog(import_type="geff")
+    qtbot.addWidget(dialog)
+    mock_qmessagebox.question.return_value = getattr(mock_qmessagebox, answer_attr)
+
+    assert dialog._maybe_convert_legacy_masks(legacy_mask_geff) is expected
+    assert _mask_dtype(legacy_mask_geff) == np.dtype(np.uint64)
+
+
+def test_bool_masks_are_not_offered_for_conversion(
+    qtbot, tmp_path, graph_2d, mock_qmessagebox
+):
+    """Masks already written as bool need no dialog and no conversion."""
+    tracks = Tracks(graph_2d, ndim=3, time_attr="t", tracklet_attr="track_id")
+    geff_dir = _write_geff(tracks, tmp_path / "current.zarr")
+    assert _mask_dtype(geff_dir) == np.dtype(bool)
+
+    dialog = ImportDialog(import_type="geff")
+    qtbot.addWidget(dialog)
+
+    assert dialog._maybe_convert_legacy_masks(geff_dir) is True
+    mock_qmessagebox.question.assert_not_called()
+
+
+def test_missing_mask_prop_is_not_offered_for_conversion(
+    qtbot, tmp_path, graph_2d_without_segmentation, mock_qmessagebox
+):
+    """A geff without a mask prop (points-only tracks) is imported unchanged."""
+    tracks = Tracks(
+        graph_2d_without_segmentation, ndim=3, time_attr="t", tracklet_attr="track_id"
+    )
+    geff_dir = _write_geff(tracks, tmp_path / "points_only.zarr")
+    assert _mask_dtype(geff_dir) is None
+
+    dialog = ImportDialog(import_type="geff")
+    qtbot.addWidget(dialog)
+
+    assert dialog._maybe_convert_legacy_masks(geff_dir) is True
+    mock_qmessagebox.question.assert_not_called()
+
+
+def test_failed_conversion_aborts_import(
+    qtbot, legacy_mask_geff, monkeypatch, mock_qmessagebox
+):
+    """A conversion error (e.g. a read-only store) is reported and aborts the import."""
+    import tracksdata.io
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("zarr store is read-only")
+
+    monkeypatch.setattr(tracksdata.io, "convert_geff_prop_dtype", boom)
+    mock_qmessagebox.critical.side_effect = None  # allow the error dialog
+    mock_qmessagebox.question.return_value = mock_qmessagebox.Yes
+
+    dialog = ImportDialog(import_type="geff")
+    qtbot.addWidget(dialog)
+
+    assert dialog._maybe_convert_legacy_masks(legacy_mask_geff) is False
+    assert mock_qmessagebox.critical.called
+    assert _mask_dtype(legacy_mask_geff) == np.dtype(np.uint64)
+
+
+def test_missing_tracksdata_helpers_do_not_block_import(
+    qtbot, legacy_mask_geff, monkeypatch, mock_qmessagebox
+):
+    """Against a tracksdata without the helpers, the import proceeds untouched.
+
+    Released tracksdata does not yet have them, so the dialog imports them
+    defensively; this covers that fallback.
+    """
+    import tracksdata.io
+
+    monkeypatch.delattr(tracksdata.io, "geff_prop_dtype", raising=False)
+    monkeypatch.delattr(tracksdata.io, "convert_geff_prop_dtype", raising=False)
+
+    dialog = ImportDialog(import_type="geff")
+    qtbot.addWidget(dialog)
+
+    assert dialog._maybe_convert_legacy_masks(legacy_mask_geff) is True
+    mock_qmessagebox.question.assert_not_called()
+
+
+def test_legacy_mask_geff_imports_after_conversion(
+    qtbot, legacy_mask_geff, monkeypatch, mock_qmessagebox
+):
+    """Full import path: a uint64-mask geff converts and still loads its segmentation."""
+    monkeypatch.setattr(ImportDialog, "_resize_dialog", lambda self: None)
+
+    dialog = ImportDialog(import_type="geff")
+    qtbot.addWidget(dialog)
+    dialog.import_widget._load_geff(legacy_mask_geff.parent)
+    mock_qmessagebox.question.return_value = mock_qmessagebox.Yes
+
+    dialog._finish()
+
+    assert _mask_dtype(legacy_mask_geff) == np.dtype(bool)
+    assert dialog.tracks is not None
+    assert dialog.tracks.segmentation is not None


### PR DESCRIPTION
**Problem:** 
The geff stores our masks and bounding boxes to display the segmentation. The problem is that previously, these masks were saved as `uint64`. On disc, this is fine, because zarr compression can do a lot on binary masks. However, when loading the geff into memory (like we do in motile_tracker), it makes memory explode, because the binary masks are loaded as full `uint64`. Actually, funtracks uses the tracksdata functionality to load the geff, and tracksdata casts to bools upon loading, but the problem is the `geff.load` which goes through `uint64` because that is the type it sees. 

Tracksdata has been updated to export the masks as `bool`, so every future geff will have boolean masks (once tracksdata>funtracks>motile_tracker all use the latest releases). However, in the meantime, all previously saved geffs have the masks as `uint64`. 

**This PR:** 
When loading a geff in which the masks are saved as `uint64`, the UI pops up a window with the question to convert the masks to booleans. This will duplicate the geff with the masks as booleans and load that one. This is a tracksdata utility that motile_tracker uses, and the conversion is fast, because it works on chunks, so OOM is not a risk. 

For small datasets, this won't be a problem, but for larger datasets (>25k nodes) on smaller laptops, the **8-fold** memory increase because of `uint64` is a major problem. 


🔴 currently blocked until https://github.com/royerlab/tracksdata/pull/319 is part of the next tracksdata release (it is merged with td::main already). After next td release, remove the td pin in pyproject here