### PR TITLE
segmentation_shape consistency

### DIFF
--- a/.github/workflows/benchmark_pr.py
+++ b/.github/workflows/benchmark_pr.py
@@ -63,13 +63,15 @@ def make_report(old_path, new_path, out_file, header=None):
         df = pd.DataFrame(
             {
                 "Benchmark": new_df["Benchmark"],
+                f"Median (s) HEAD {new_commit}": new_df["median"].map("{:.5f}".format),
                 f"Mean ± SD (s) HEAD {new_commit}": [
                     _fmt(m, s)
                     for m, s in zip(new_df["mean"], new_df["stddev"], strict=True)
                 ],
             }
         )
-        report = df.to_markdown(index=False)
+        # disable_numparse: see note on the comparison table below.
+        report = df.to_markdown(index=False, disable_numparse=True)
         note = "_No baseline found; showing HEAD results only (no comparison)._"
         report = f"{note}\n\n{report}"
         if header:
@@ -87,9 +89,15 @@ def make_report(old_path, new_path, out_file, header=None):
         100 * (merged["median_new"] - merged["median_old"]) / merged["median_old"]
     )
 
+    # Median columns first: they drive the gate, so "Median Change" is verifiable
+    # straight from them. Mean ± SD follows as a noise indicator (a wide SD or a mean
+    # far from the median flags a spiky benchmark whose median we're rightly trusting).
     df = pd.DataFrame(
         {
             "Benchmark": merged["Benchmark"],
+            f"Median (s) BASE {old_commit}": merged["median_old"].map("{:.5f}".format),
+            f"Median (s) HEAD {new_commit}": merged["median_new"].map("{:.5f}".format),
+            "Median Change": pct_change.map("{:+.2f}%".format),
             f"Mean ± SD (s) BASE {old_commit}": [
                 _fmt(m, s)
                 for m, s in zip(merged["mean_old"], merged["stddev_old"], strict=True)
@@ -98,11 +106,13 @@ def make_report(old_path, new_path, out_file, header=None):
                 _fmt(m, s)
                 for m, s in zip(merged["mean_new"], merged["stddev_new"], strict=True)
             ],
-            "Median Change": pct_change.map("{:+.2f}%".format),
         }
     )
 
-    report = df.to_markdown(index=False)
+    # disable_numparse: keep our fixed-precision strings exactly (tabulate otherwise
+    # re-parses numeric-looking cells and strips trailing zeros, so medians would show
+    # inconsistent precision next to the mean ± SD column).
+    report = df.to_markdown(index=False, disable_numparse=True)
     if header:
         report = f"## {header}\n\n{report}"
     _write(out_file, report)

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -39,9 +39,6 @@ jobs:
           python-version: "3.13"
           enable-cache: true
 
-      - name: Install dependencies
-        run: uv sync --no-dev --group testing
-
       - name: Set Windows resolution
         if: runner.os == 'Windows'
         run: Set-DisplayResolution -Width 1920 -Height 1080 -Force

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -22,7 +22,9 @@ jobs:
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
     env:
-      # disable resyncing on uv run so `git checkout <base>` keeps the head-synced env
+      # Stop `uv run` from auto-resyncing (which would drop the `testing` group).
+      # Each benchmark step below runs its own explicit `uv sync` after checkout so
+      # base and head are each measured against *their own* locked dependencies.
       UV_NO_SYNC: "1"
 
     steps:
@@ -62,6 +64,14 @@ jobs:
       # essential: CI runners -- especially macOS/Windows -- vary enough machine-to-machine
       # that comparing against a baseline cached from a different run produced spurious
       # regressions larger than the real deltas.
+      #
+      # Each side re-syncs its OWN dependencies after checkout (`uv sync` after `git
+      # checkout`). This is what makes dependency-bump PRs (funtracks/tracksdata/...)
+      # measure the real base-vs-head delta: base runs against base's locked deps and
+      # head against head's. Without the per-checkout sync, base code would run against
+      # head's deps -- an apples-to-oranges comparison that reports fictional regressions
+      # whenever a dependency changes a shared contract. `git checkout -f` discards any
+      # uv.lock churn from the previous sync so the next checkout is clean.
       # Tolerant on purpose: the base commit may predate the benchmark suite, in which
       # case there is no baseline and the report falls back to HEAD-only numbers.
       - name: Run baseline benchmark (same runner)
@@ -69,14 +79,16 @@ jobs:
         uses: aganders3/headless-gui@v2
         with:
           run: |
-            git checkout ${{ github.event.pull_request.base.sha }}
+            git checkout -f ${{ github.event.pull_request.base.sha }}
+            uv sync --no-dev --group testing
             uv run pytest tests/benchmarks -o addopts= --benchmark-json baseline.json
 
       - name: Run benchmark on PR head
         uses: aganders3/headless-gui@v2
         with:
           run: |
-            git checkout ${{ github.event.pull_request.head.sha }}
+            git checkout -f ${{ github.event.pull_request.head.sha }}
+            uv sync --no-dev --group testing
             uv run pytest tests/benchmarks -o addopts= --benchmark-json pr.json
 
       - name: Generate report

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,7 @@ conflicts = [
 # TEMPORARY: pin funtracks to the segmentation-shape PR commit until it is merged
 # and released. Revert to the PyPI version (drop this source) once released.
 [tool.uv.sources]
-funtracks = { git = "https://github.com/funkelab/funtracks.git", rev = "204388f535f6f17d72c6415e3b8a3d48ece073a4" }
+funtracks = { git = "https://github.com/funkelab/funtracks.git", rev = "c0af650025de47351738a5637a96e02e51ce7ee5" }
 
 [tool.pytest.ini_options]
 # Benchmarks are slow and run in a dedicated CI job; exclude them from the normal

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,7 @@ conflicts = [
 # TEMPORARY: pin funtracks to the segmentation-shape PR commit until it is merged
 # and released. Revert to the PyPI version (drop this source) once released.
 [tool.uv.sources]
-funtracks = { git = "https://github.com/funkelab/funtracks.git", rev = "c68931978a0a0d2ab235cd1712647e09fdb4f96b" }
+funtracks = { git = "https://github.com/funkelab/funtracks.git", rev = "204388f535f6f17d72c6415e3b8a3d48ece073a4" }
 
 [tool.pytest.ini_options]
 # Benchmarks are slow and run in a dedicated CI job; exclude them from the normal

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,11 @@ conflicts = [
     ],
 ]
 
+# TEMPORARY: pin funtracks to the segmentation-shape PR commit until it is merged
+# and released. Revert to the PyPI version (drop this source) once released.
+[tool.uv.sources]
+funtracks = { git = "https://github.com/funkelab/funtracks.git", rev = "c68931978a0a0d2ab235cd1712647e09fdb4f96b" }
+
 [tool.pytest.ini_options]
 # Benchmarks are slow and run in a dedicated CI job; exclude them from the normal
 # test suite (`just test` / `pytest .`). Run with `pytest tests/benchmarks -o addopts=`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 
 dependencies =[
     "napari>=0.6.2,<0.8.0",
-    "funtracks>=2.0.4,<3",
+    "funtracks>=2.1.0-a3,<3",
     "appdirs>=1,<2",
     "numpy>=2,<3",
     "magicgui>=0.10.1",
@@ -100,11 +100,6 @@ conflicts = [
         {extra = "gurobi13"},
     ],
 ]
-
-# TEMPORARY: pin funtracks to the segmentation-shape PR commit until it is merged
-# and released. Revert to the PyPI version (drop this source) once released.
-[tool.uv.sources]
-funtracks = { git = "https://github.com/funkelab/funtracks.git", rev = "ec1d3257e24f7411804d50e8c5e7981d4b92cad1" }
 
 [tool.pytest.ini_options]
 # Benchmarks are slow and run in a dedicated CI job; exclude them from the normal

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,7 @@ conflicts = [
 # TEMPORARY: pin funtracks to the segmentation-shape PR commit until it is merged
 # and released. Revert to the PyPI version (drop this source) once released.
 [tool.uv.sources]
-funtracks = { git = "https://github.com/funkelab/funtracks.git", rev = "c0af650025de47351738a5637a96e02e51ce7ee5" }
+funtracks = { git = "https://github.com/funkelab/funtracks.git", rev = "ec1d3257e24f7411804d50e8c5e7981d4b92cad1" }
 
 [tool.pytest.ini_options]
 # Benchmarks are slow and run in a dedicated CI job; exclude them from the normal

--- a/src/motile_tracker/import_export/menus/geff_import_utils.py
+++ b/src/motile_tracker/import_export/menus/geff_import_utils.py
@@ -1,7 +1,25 @@
+from pathlib import Path
+
 import zarr
+from funtracks.utils import get_store_path
 from qtpy.QtWidgets import (
     QLayout,
 )
+
+
+def geff_group_path(root: zarr.Group) -> Path:
+    """Return the filesystem path to a geff zarr group.
+
+    Handles both zarr v2 and v3: works from the group's store and its relative
+    path within that store, rather than v3-only attributes like `store_path`.
+
+    Args:
+        root (zarr.Group): The geff group (may be a subgroup of its store).
+
+    Returns:
+        Path: The filesystem path to the geff group itself.
+    """
+    return get_store_path(root.store) / Path(root.path)
 
 
 def find_geff_group(group: zarr.Group) -> zarr.Group | None:

--- a/src/motile_tracker/import_export/menus/import_dialog.py
+++ b/src/motile_tracker/import_export/menus/import_dialog.py
@@ -1,7 +1,11 @@
 from pathlib import Path
 
 import numpy as np
-from funtracks.import_export import import_from_geff, tracks_from_df
+from funtracks.import_export import (
+    has_embedded_segmentation,
+    import_from_geff,
+    tracks_from_df,
+)
 from funtracks.import_export.magic_imread import magic_imread
 from geff_spec.utils import axes_from_lists
 from qtpy.QtCore import Qt
@@ -31,7 +35,6 @@ from motile_tracker.import_export.menus.scale_widget import ScaleWidget
 from motile_tracker.import_export.menus.segmentation_widgets import (
     CSVSegmentationWidget,
     GeffSegmentationWidget,
-    geff_has_embedded_segmentation,
 )
 
 
@@ -153,7 +156,7 @@ class ImportDialog(QDialog):
                     self.seg,
                     self.incl_z,
                     seg_for_features=self.seg
-                    or geff_has_embedded_segmentation(self.import_widget.root),
+                    or has_embedded_segmentation(self.import_widget.root.store_path),
                 )
 
             else:
@@ -413,8 +416,8 @@ class ImportDialog(QDialog):
                 # external segmentation file is provided, ensure those attributes are
                 # loaded so funtracks can reconstruct the segmentation as a
                 # GraphArrayView.
-                if segmentation_path is None and geff_has_embedded_segmentation(
-                    self.import_widget.root
+                if segmentation_path is None and has_embedded_segmentation(
+                    self.import_widget.root.store_path
                 ):
                     name_map.setdefault("mask", "mask")
                     name_map.setdefault("bbox", "bbox")

--- a/src/motile_tracker/import_export/menus/import_dialog.py
+++ b/src/motile_tracker/import_export/menus/import_dialog.py
@@ -27,6 +27,7 @@ from motile_tracker.import_export.menus.csv_dimension_widget import (
 from motile_tracker.import_export.menus.csv_import_widget import (
     ImportCSVWidget,
 )
+from motile_tracker.import_export.menus.geff_import_utils import geff_group_path
 from motile_tracker.import_export.menus.geff_import_widget import (
     ImportGeffWidget,
 )
@@ -156,7 +157,9 @@ class ImportDialog(QDialog):
                     self.seg,
                     self.incl_z,
                     seg_for_features=self.seg
-                    or has_embedded_segmentation(self.import_widget.root.store_path),
+                    or has_embedded_segmentation(
+                        geff_group_path(self.import_widget.root)
+                    ),
                 )
 
             else:
@@ -416,9 +419,7 @@ class ImportDialog(QDialog):
                 # external segmentation file is provided, ensure those attributes are
                 # loaded so funtracks can reconstruct the segmentation as a
                 # GraphArrayView.
-                if segmentation_path is None and has_embedded_segmentation(
-                    self.import_widget.root.store_path
-                ):
+                if segmentation_path is None and has_embedded_segmentation(geff_dir):
                     name_map.setdefault("mask", "mask")
                     name_map.setdefault("bbox", "bbox")
 

--- a/src/motile_tracker/import_export/menus/prop_map_widget.py
+++ b/src/motile_tracker/import_export/menus/prop_map_widget.py
@@ -178,7 +178,7 @@ class StandardFieldMapWidget(QWidget):
         self.metadata = dict(root.attrs.get("geff", {}))
 
         # Exclude mask/bbox from optional features when they are embedded segmentation
-        # attributes that will be imported automatically (segmentation_shape present).
+        # attributes that will be imported automatically (shape metadata present).
         if geff_has_embedded_segmentation(root):
             self.node_attrs = [a for a in self.node_attrs if a not in ("mask", "bbox")]
 

--- a/src/motile_tracker/import_export/menus/prop_map_widget.py
+++ b/src/motile_tracker/import_export/menus/prop_map_widget.py
@@ -7,6 +7,7 @@ from funtracks.annotators._track_annotator import (
     DEFAULT_LINEAGE_KEY,
     DEFAULT_TRACKLET_KEY,
 )
+from funtracks.import_export import has_embedded_segmentation
 from funtracks.import_export._utils import get_default_key_to_feature_mapping
 from psygnal import Signal
 from qtpy.QtCore import Qt
@@ -24,9 +25,6 @@ from qtpy.QtWidgets import (
 
 from motile_tracker.import_export.menus.geff_import_utils import (
     clear_layout,
-)
-from motile_tracker.import_export.menus.segmentation_widgets import (
-    geff_has_embedded_segmentation,
 )
 
 
@@ -179,7 +177,7 @@ class StandardFieldMapWidget(QWidget):
 
         # Exclude mask/bbox from optional features when they are embedded segmentation
         # attributes that will be imported automatically (shape metadata present).
-        if geff_has_embedded_segmentation(root):
+        if has_embedded_segmentation(root.store_path):
             self.node_attrs = [a for a in self.node_attrs if a not in ("mask", "bbox")]
 
         # Retrieve attribute types from the zarr group

--- a/src/motile_tracker/import_export/menus/prop_map_widget.py
+++ b/src/motile_tracker/import_export/menus/prop_map_widget.py
@@ -25,6 +25,7 @@ from qtpy.QtWidgets import (
 
 from motile_tracker.import_export.menus.geff_import_utils import (
     clear_layout,
+    geff_group_path,
 )
 
 
@@ -177,7 +178,7 @@ class StandardFieldMapWidget(QWidget):
 
         # Exclude mask/bbox from optional features when they are embedded segmentation
         # attributes that will be imported automatically (shape metadata present).
-        if has_embedded_segmentation(root.store_path):
+        if has_embedded_segmentation(geff_group_path(root)):
             self.node_attrs = [a for a in self.node_attrs if a not in ("mask", "bbox")]
 
         # Retrieve attribute types from the zarr group

--- a/src/motile_tracker/import_export/menus/segmentation_widgets.py
+++ b/src/motile_tracker/import_export/menus/segmentation_widgets.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import numpy as np
 import zarr
+from funtracks.import_export import has_embedded_segmentation
 from funtracks.import_export.magic_imread import magic_imread
 from funtracks.utils import get_store_path
 from psygnal import Signal
@@ -274,35 +275,6 @@ def _geff_has_mask_props(root: zarr.Group) -> bool:
         return False
 
 
-def _geff_has_shape(root: zarr.Group) -> bool:
-    """Return True if the geff store records the segmentation shape.
-
-    The shape is stored inside the geff metadata at extra.tracksdata.shape
-    (the convention shared with tracksdata). Older funtracks GEFFs stored it as a
-    top-level 'segmentation_shape' zarr attribute, which is still recognised.
-    """
-    attrs = dict(root.attrs)
-    new_shape = (
-        attrs.get("geff", {}).get("extra", {}).get("tracksdata", {}).get("shape")
-    )
-    legacy_shape = attrs.get("segmentation_shape")
-    return new_shape is not None or legacy_shape is not None
-
-
-def geff_has_embedded_segmentation(root: zarr.Group) -> bool:
-    """Return True if the geff group has embedded segmentation that can be reconstructed.
-
-    Requires both:
-    - 'mask' and 'bbox' node prop arrays in the zarr store
-    - the segmentation shape recorded in the geff metadata (extra.tracksdata.shape)
-      or the legacy top-level 'segmentation_shape' zarr attribute
-
-    When both conditions are met, funtracks will reconstruct the segmentation
-    automatically as a GraphArrayView — no external segmentation file is needed.
-    """
-    return _geff_has_mask_props(root) and _geff_has_shape(root)
-
-
 class GeffSegmentationWidget(QWidget):
     """QWidget to select segmentation data when importing from geff."""
 
@@ -399,7 +371,8 @@ class GeffSegmentationWidget(QWidget):
         clear_layout(self.related_objects_layout)
         self.related_object_radio_buttons = {}
         if self.root is not None:
-            if geff_has_embedded_segmentation(self.root):
+            has_embedded_seg = has_embedded_segmentation(self.root.store_path)
+            if has_embedded_seg:
                 # Embedded segmentation: hide radio options, show info label.
                 # segmentation_path=None will be passed to import_from_geff and
                 # funtracks will reconstruct the segmentation as a GraphArrayView.
@@ -423,7 +396,7 @@ class GeffSegmentationWidget(QWidget):
                 self._embedded_info_label.setVisible(False)
                 self._old_geff_warning_label.setVisible(False)
 
-            if not geff_has_embedded_segmentation(self.root):
+            if not has_embedded_seg:
                 metadata = dict(self.root.attrs)
                 related_objects = metadata.get("geff", {}).get("related_objects", None)
                 if related_objects:

--- a/src/motile_tracker/import_export/menus/segmentation_widgets.py
+++ b/src/motile_tracker/import_export/menus/segmentation_widgets.py
@@ -274,17 +274,33 @@ def _geff_has_mask_props(root: zarr.Group) -> bool:
         return False
 
 
+def _geff_has_shape(root: zarr.Group) -> bool:
+    """Return True if the geff store records the segmentation shape.
+
+    The shape is stored inside the geff metadata at extra.tracksdata.shape
+    (the convention shared with tracksdata). Older funtracks GEFFs stored it as a
+    top-level 'segmentation_shape' zarr attribute, which is still recognised.
+    """
+    attrs = dict(root.attrs)
+    new_shape = (
+        attrs.get("geff", {}).get("extra", {}).get("tracksdata", {}).get("shape")
+    )
+    legacy_shape = attrs.get("segmentation_shape")
+    return new_shape is not None or legacy_shape is not None
+
+
 def geff_has_embedded_segmentation(root: zarr.Group) -> bool:
     """Return True if the geff group has embedded segmentation that can be reconstructed.
 
     Requires both:
     - 'mask' and 'bbox' node prop arrays in the zarr store
-    - 'segmentation_shape' in zarr attrs (written by funtracks export_to_geff)
+    - the segmentation shape recorded in the geff metadata (extra.tracksdata.shape)
+      or the legacy top-level 'segmentation_shape' zarr attribute
 
     When both conditions are met, funtracks will reconstruct the segmentation
     automatically as a GraphArrayView — no external segmentation file is needed.
     """
-    return _geff_has_mask_props(root) and "segmentation_shape" in dict(root.attrs)
+    return _geff_has_mask_props(root) and _geff_has_shape(root)
 
 
 class GeffSegmentationWidget(QWidget):
@@ -338,10 +354,10 @@ class GeffSegmentationWidget(QWidget):
         self._embedded_info_label.setFont(font)
         self._embedded_info_label.setVisible(False)
 
-        # Warning label shown when masks/bboxes are present but segmentation_shape is
-        # missing (GEFF exported by an older version of funtracks)
+        # Warning label shown when masks/bboxes are present but the shape metadata
+        # is missing (GEFF exported by an older version of funtracks or external tool)
         self._old_geff_warning_label = QLabel(
-            "⚠ This GEFF contains mask/bbox data but no segmentation_shape. "
+            "⚠ This GEFF contains mask/bbox data but no shape metadata. "
             "The segmentation cannot be reconstructed automatically. "
             "Re-export with an updated version of funtracks, or provide an "
             "external segmentation file below."
@@ -394,7 +410,7 @@ class GeffSegmentationWidget(QWidget):
                 self._old_geff_warning_label.setVisible(False)
                 self.none_radio.setChecked(True)
             elif _geff_has_mask_props(self.root):
-                # Old GEFF: masks present but segmentation_shape missing.
+                # Old GEFF: masks present but shape metadata missing.
                 # Show a warning and the normal options so the user can provide
                 # an external segmentation or skip it.
                 self.none_radio.setVisible(True)

--- a/src/motile_tracker/import_export/menus/segmentation_widgets.py
+++ b/src/motile_tracker/import_export/menus/segmentation_widgets.py
@@ -5,7 +5,6 @@ import numpy as np
 import zarr
 from funtracks.import_export import has_embedded_segmentation
 from funtracks.import_export.magic_imread import magic_imread
-from funtracks.utils import get_store_path
 from psygnal import Signal
 from qtpy.QtWidgets import (
     QButtonGroup,
@@ -25,6 +24,7 @@ from qtpy.QtWidgets import (
 
 from motile_tracker.import_export.menus.geff_import_utils import (
     clear_layout,
+    geff_group_path,
 )
 
 
@@ -371,7 +371,7 @@ class GeffSegmentationWidget(QWidget):
         clear_layout(self.related_objects_layout)
         self.related_object_radio_buttons = {}
         if self.root is not None:
-            has_embedded_seg = has_embedded_segmentation(self.root.store_path)
+            has_embedded_seg = has_embedded_segmentation(geff_group_path(self.root))
             if has_embedded_seg:
                 # Embedded segmentation: hide radio options, show info label.
                 # segmentation_path=None will be passed to import_from_geff and
@@ -436,10 +436,7 @@ class GeffSegmentationWidget(QWidget):
 
         for path, radio in self.related_object_radio_buttons.items():
             if radio.isChecked():
-                store_path = get_store_path(self.root.store)  # e.g. /.../geff.zarr
-                group_path = Path(self.root.path)  # e.g. 'tracks'
-                full_group_path = store_path / group_path  # /.../geff.zarr/tracks
-                seg_path = (full_group_path / path).resolve()
+                seg_path = (geff_group_path(self.root) / path).resolve()
                 return seg_path
         if self.external_segmentation_radio.isChecked():
             return self.segmentation_widget.get_segmentation_path()

--- a/src/motile_tracker/motile/backend/motile_run.py
+++ b/src/motile_tracker/motile/backend/motile_run.py
@@ -157,9 +157,11 @@ class MotileRun(SolutionTracks):
         else:
             tracks = import_from_geff(run_dir / "tracks")
         if attrs is not None:
-            seg_shape = attrs.get("segmentation_shape")
+            # New runs use the "shape" key; fall back to the legacy
+            # "segmentation_shape" key for runs saved by older versions.
+            seg_shape = attrs.get("shape", attrs.get("segmentation_shape"))
             if seg_shape is not None:
-                tracks.graph._update_metadata(segmentation_shape=tuple(seg_shape))
+                tracks.graph._update_metadata(shape=tuple(seg_shape))
             scale = attrs.get("scale") or tracks.scale
             time_attr = attrs.get("time_attr") or tracks.features.time_key
         else:
@@ -259,20 +261,20 @@ class MotileRun(SolutionTracks):
             return None
 
     def _save_attrs(self, directory: Path):
-        """Save the time_attr, pos_attr, scale, and segmentation_shape in a json file.
+        """Save the time_attr, pos_attr, scale, and shape in a json file.
 
         Args:
             directory (Path):  The directory in which to save the attributes
         """
         out_path = directory / ATTRS_FILENAME
-        seg_shape = self.graph.metadata.get("segmentation_shape")
+        seg_shape = self.graph.metadata.get("shape")
         scale = (
             self.scale
             if not isinstance(self.scale, np.ndarray)
             else self.scale.tolist()
         )
         attrs_dict = {
-            "segmentation_shape": list(seg_shape) if seg_shape is not None else None,
+            "shape": list(seg_shape) if seg_shape is not None else None,
             "scale": scale,
             "time_attr": self.features.time_key,
         }

--- a/src/motile_tracker/motile/backend/solve.py
+++ b/src/motile_tracker/motile/backend/solve.py
@@ -80,7 +80,7 @@ def solve(
             result = _solve_full(cand_graph, solver_params, on_solver_update)
 
     if input_data.ndim != 2:
-        result._update_metadata(segmentation_shape=input_data.shape)
+        result._update_metadata(shape=input_data.shape)
 
     return result
 

--- a/src/motile_tracker/motile/menus/motile_widget.py
+++ b/src/motile_tracker/motile/menus/motile_widget.py
@@ -156,7 +156,7 @@ class MotileWidget(QWidget):
             ndim=run.ndim,
         )
         if "mask" in run.graph.node_attr_keys():
-            seg_shape = run.graph.metadata.get("segmentation_shape")
+            seg_shape = run.graph.metadata.get("shape")
             if seg_shape is not None:
                 run.segmentation = GraphArrayView(
                     graph=run.graph, shape=seg_shape, attr_key="node_id", offset=0

--- a/tests/benchmarks/bench_data_model.py
+++ b/tests/benchmarks/bench_data_model.py
@@ -11,6 +11,9 @@ funtracks' code and is covered by funtracks' own benchmark suite.)
 from __future__ import annotations
 
 import napari
+from bench_ui_actions import (
+    ROUNDS,  # shared round count (median-gated; see that module)
+)
 
 from motile_tracker.data_views.views.tree_view.tree_widget_utils import (
     extract_sorted_tracks,
@@ -27,6 +30,6 @@ def test_extract_sorted_tracks(benchmark, shared_tracks):
     cmap = _colormap()
     benchmark.pedantic(
         lambda: extract_sorted_tracks(shared_tracks, cmap),
-        rounds=3,
+        rounds=ROUNDS,
         iterations=1,
     )

--- a/tests/benchmarks/synthetic_data.py
+++ b/tests/benchmarks/synthetic_data.py
@@ -230,7 +230,7 @@ def build_graph(params: SyntheticParams = LARGE) -> td.graph.GraphView:
 
     graph.bulk_add_nodes(nodes=nodes, indices=indices)
     graph.bulk_add_edges(edges)
-    graph._update_metadata(segmentation_shape=(params.n_frames, *params.frame_shape))
+    graph._update_metadata(shape=(params.n_frames, *params.frame_shape))
     return graph
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -163,7 +163,7 @@ def graph_2d() -> td.graph.GraphView:
             {"source_id": 4, "target_id": 5, "iou": 1.0, "solution": True},
         ]
     )
-    graph._update_metadata(segmentation_shape=(5, 100, 100))
+    graph._update_metadata(shape=(5, 100, 100))
     return graph
 
 
@@ -198,7 +198,7 @@ def graph_3d() -> td.graph.GraphView:
             {"source_id": 1, "target_id": 3, "solution": True},
         ]
     )
-    graph._update_metadata(segmentation_shape=(2, 100, 100, 100))
+    graph._update_metadata(shape=(2, 100, 100, 100))
     return graph
 
 
@@ -286,7 +286,7 @@ def graph_3d_with_division() -> td.graph.GraphView:
             {"source_id": 2, "target_id": 4, "solution": True},
         ]
     )
-    graph._update_metadata(segmentation_shape=(5, 100, 100, 100))
+    graph._update_metadata(shape=(5, 100, 100, 100))
     return graph
 
 

--- a/tests/data_views/test_center_view.py
+++ b/tests/data_views/test_center_view.py
@@ -24,7 +24,7 @@ def _make_single_node_graph(
         tmp_path: Pytest tmp_path for the SQLite database.
         pos: Node position in world coordinates [z, y, x].
         seg_bbox: Bounding box [z0, y0, x0, z1, y1, x1] for the node's mask.
-            If provided, mask/bbox node attributes and segmentation_shape metadata
+            If provided, mask/bbox node attributes and shape metadata
             are added so SolutionTracks can reconstruct the segmentation.
         seg_shape: Full segmentation array shape (t, z, y, x). Required when
             seg_bbox is provided.
@@ -51,7 +51,7 @@ def _make_single_node_graph(
     graph.bulk_add_nodes(nodes=[node], indices=[1])
 
     if seg_shape is not None:
-        graph._update_metadata(segmentation_shape=seg_shape)
+        graph._update_metadata(shape=seg_shape)
 
     return graph
 

--- a/tests/import_export/test_import_dialog.py
+++ b/tests/import_export/test_import_dialog.py
@@ -36,6 +36,10 @@ def _remove_geff_shape(root):
     extra["tracksdata"] = tracksdata
     geff_meta["extra"] = extra
     root.attrs["geff"] = geff_meta
+    # funtracks also writes a legacy top-level "segmentation_shape" attr; drop it
+    # too so the store truly has no shape metadata.
+    if "segmentation_shape" in root.attrs:
+        del root.attrs["segmentation_shape"]
 
 
 @pytest.fixture(autouse=True)

--- a/tests/import_export/test_import_dialog.py
+++ b/tests/import_export/test_import_dialog.py
@@ -700,10 +700,7 @@ def test_geff_import_embedded_segmentation(qtbot, tmp_path, graph_2d, monkeypatc
     export_to_geff(tracks, geff_path, save_segmentation=False)
 
     # Verify that the geff has embedded segmentation (precondition)
-    import zarr as _zarr
-
-    root = _zarr.open_group(geff_path / "tracks.geff", mode="r")
-    assert has_embedded_segmentation(root.store_path), (
+    assert has_embedded_segmentation(geff_path / "tracks.geff"), (
         "Precondition: geff should have mask/bbox and shape"
     )
 

--- a/tests/import_export/test_import_dialog.py
+++ b/tests/import_export/test_import_dialog.py
@@ -24,6 +24,20 @@ from motile_tracker.motile.backend.motile_run import MotileRun
 from motile_tracker.motile.backend.solver_params import SolverParams
 
 
+def _remove_geff_shape(root):
+    """Remove the shape from a geff store's extra.tracksdata metadata (in place).
+
+    Simulates a GEFF with mask/bbox but no shape (e.g. from an external tool).
+    """
+    geff_meta = dict(root.attrs["geff"])
+    extra = dict(geff_meta.get("extra", {}))
+    tracksdata = dict(extra.get("tracksdata", {}))
+    tracksdata.pop("shape", None)
+    extra["tracksdata"] = tracksdata
+    geff_meta["extra"] = extra
+    root.attrs["geff"] = geff_meta
+
+
 @pytest.fixture(autouse=True)
 def mock_qmessagebox(monkeypatch):
     """Mock QMessageBox to prevent blocking popups in all tests.
@@ -630,11 +644,11 @@ def test_geff_import_without_axes_metadata(
 
 
 def test_geff_import_embedded_segmentation(qtbot, tmp_path, graph_2d, monkeypatch):
-    """Test that embedded segmentation (mask/bbox + segmentation_shape) is reconstructed.
+    """Test that embedded segmentation (mask/bbox + shape) is reconstructed.
 
     Regression test for the bug where mask/bbox were not included in the name_map
     passed to import_from_geff, causing tracks.segmentation to be None even though
-    the GEFF contained embedded mask data and a segmentation_shape zarr attribute.
+    the GEFF contained embedded mask data and a recorded shape.
     """
     monkeypatch.setattr(ImportDialog, "_resize_dialog", lambda self: None)
 
@@ -647,7 +661,7 @@ def test_geff_import_embedded_segmentation(qtbot, tmp_path, graph_2d, monkeypatc
 
     root = _zarr.open_group(geff_path / "tracks.geff", mode="r")
     assert geff_has_embedded_segmentation(root), (
-        "Precondition: geff should have mask/bbox and segmentation_shape"
+        "Precondition: geff should have mask/bbox and shape"
     )
 
     dialog = ImportDialog(import_type="geff")
@@ -690,7 +704,7 @@ def test_geff_import_embedded_segmentation(qtbot, tmp_path, graph_2d, monkeypatc
 
 def test_geff_import_old_geff_warning(qtbot, tmp_path, graph_2d, monkeypatch):
     """Test that the old GEFF warning is shown when mask/bbox is present but
-    segmentation_shape is missing (simulating a GEFF exported by an older funtracks).
+    the shape is missing (simulating a GEFF from an external tool).
     """
     monkeypatch.setattr(ImportDialog, "_resize_dialog", lambda self: None)
 
@@ -698,9 +712,9 @@ def test_geff_import_old_geff_warning(qtbot, tmp_path, graph_2d, monkeypatch):
     geff_path = tmp_path / "old_geff.zarr"
     export_to_geff(tracks, geff_path, save_segmentation=False)
 
-    # Remove segmentation_shape to simulate old funtracks export
+    # Remove the shape to simulate a GEFF without shape metadata
     root = zarr.open_group(geff_path / "tracks.geff", mode="r+")
-    del root.attrs["segmentation_shape"]
+    _remove_geff_shape(root)
 
     dialog = ImportDialog(import_type="geff")
     qtbot.addWidget(dialog)
@@ -708,7 +722,7 @@ def test_geff_import_old_geff_warning(qtbot, tmp_path, graph_2d, monkeypatch):
 
     assert dialog.import_widget.root is not None
 
-    # Old GEFF warning should be shown (mask/bbox present, no segmentation_shape)
+    # Old GEFF warning should be shown (mask/bbox present, no shape)
     assert not dialog.segmentation_widget._old_geff_warning_label.isHidden()
     assert dialog.segmentation_widget._embedded_info_label.isHidden()
     assert not dialog.segmentation_widget.none_radio.isHidden()
@@ -742,7 +756,6 @@ def test_geff_import_with_related_data(qtbot, tmp_path, graph_2d, monkeypatch):
     import shutil
 
     root = zarr.open_group(geff_path / "tracks.geff", mode="r+")
-    del root.attrs["segmentation_shape"]
 
     geff_meta = dict(root.attrs["geff"])
     node_props_meta = dict(geff_meta["node_props_metadata"])
@@ -751,6 +764,7 @@ def test_geff_import_with_related_data(qtbot, tmp_path, graph_2d, monkeypatch):
     geff_meta["node_props_metadata"] = node_props_meta
     extra = dict(geff_meta.get("extra", {}))
     extra.pop("funtracks", None)
+    extra.pop("tracksdata", None)  # drop the recorded shape
     geff_meta["extra"] = extra
     root.attrs["geff"] = geff_meta
 
@@ -797,8 +811,11 @@ def test_geff_import_with_related_data(qtbot, tmp_path, graph_2d, monkeypatch):
 def test_geff_import_no_mask_with_segmentation_shape(
     qtbot, tmp_path, graph_2d_without_segmentation, monkeypatch
 ):
-    """Test that injecting segmentation_shape without mask/bbox shows the normal
-    flow (no warning, no embedded info) and produces no segmentation on import.
+    """Test that injecting a shape without mask/bbox shows the normal flow
+    (no warning, no embedded info) and produces no segmentation on import.
+
+    Uses the legacy top-level ``segmentation_shape`` zarr attribute, which also
+    exercises the legacy shape-detection fallback.
     """
     monkeypatch.setattr(ImportDialog, "_resize_dialog", lambda self: None)
 
@@ -806,10 +823,8 @@ def test_geff_import_no_mask_with_segmentation_shape(
     geff_path = tmp_path / "no_mask_with_shape.zarr"
     export_to_geff(tracks, geff_path, save_segmentation=False)
 
-    # Manually inject segmentation_shape even though no mask/bbox exist
+    # Manually inject a (legacy) shape attr even though no mask/bbox exist
     root = zarr.open_group(geff_path / "tracks.geff", mode="r+")
-    attrs = dict(root.attrs)
-    attrs["segmentation_shape"] = [5, 100, 100]
     root.attrs["segmentation_shape"] = [5, 100, 100]
 
     dialog = ImportDialog(import_type="geff")

--- a/tests/import_export/test_import_dialog.py
+++ b/tests/import_export/test_import_dialog.py
@@ -14,12 +14,13 @@ import pytest
 import tifffile
 import zarr
 from funtracks.data_model import Tracks
-from funtracks.import_export import export_to_csv, export_to_geff
+from funtracks.import_export import (
+    export_to_csv,
+    export_to_geff,
+    has_embedded_segmentation,
+)
 
 from motile_tracker.import_export.menus.import_dialog import ImportDialog
-from motile_tracker.import_export.menus.segmentation_widgets import (
-    geff_has_embedded_segmentation,
-)
 from motile_tracker.motile.backend.motile_run import MotileRun
 from motile_tracker.motile.backend.solver_params import SolverParams
 
@@ -702,7 +703,7 @@ def test_geff_import_embedded_segmentation(qtbot, tmp_path, graph_2d, monkeypatc
     import zarr as _zarr
 
     root = _zarr.open_group(geff_path / "tracks.geff", mode="r")
-    assert geff_has_embedded_segmentation(root), (
+    assert has_embedded_segmentation(root.store_path), (
         "Precondition: geff should have mask/bbox and shape"
     )
 

--- a/tests/import_export/test_segmentation_widgets.py
+++ b/tests/import_export/test_segmentation_widgets.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 
 import numpy as np
 import zarr
+from geff_spec import GeffMetadata
 
 from motile_tracker.import_export.menus.segmentation_widgets import (
     CSVSegmentationWidget,
@@ -12,6 +13,18 @@ from motile_tracker.import_export.menus.segmentation_widgets import (
     FileFolderDialog,
     GeffSegmentationWidget,
 )
+
+
+def _minimal_geff_attrs(**overrides) -> dict:
+    """Build a minimal but schema-valid 'geff' zarr attrs dict for test fixtures.
+
+    GeffMetadata.read validates the full geff_spec schema, so fixtures need more
+    than just the fields under test (e.g. related_objects) to be readable.
+    """
+    metadata = GeffMetadata(
+        directed=True, node_props_metadata={}, edge_props_metadata={}, **overrides
+    )
+    return metadata.model_dump(mode="json", exclude_none=True)
 
 
 class TestExternalSegmentationWidget:
@@ -400,6 +413,7 @@ class TestGeffSegmentationWidget:
         # Create zarr group
         zarr_path = tmp_path / "test.zarr"
         root = zarr.open_group(str(zarr_path), mode="w")
+        root.attrs["geff"] = _minimal_geff_attrs()
 
         widget.update_root(root)
 
@@ -413,12 +427,12 @@ class TestGeffSegmentationWidget:
         # Create zarr group with related objects metadata
         zarr_path = tmp_path / "test.zarr"
         root = zarr.open_group(str(zarr_path), mode="w")
-        root.attrs["geff"] = {
-            "related_objects": [
+        root.attrs["geff"] = _minimal_geff_attrs(
+            related_objects=[
                 {"type": "labels", "path": "segmentation"},
                 {"type": "labels", "path": "masks"},
             ]
-        }
+        )
 
         widget.update_root(root)
 
@@ -435,14 +449,18 @@ class TestGeffSegmentationWidget:
         # First update with related objects
         zarr_path1 = tmp_path / "test1.zarr"
         root1 = zarr.open_group(str(zarr_path1), mode="w")
-        root1.attrs["geff"] = {"related_objects": [{"type": "labels", "path": "seg1"}]}
+        root1.attrs["geff"] = _minimal_geff_attrs(
+            related_objects=[{"type": "labels", "path": "seg1"}]
+        )
         widget.update_root(root1)
         assert len(widget.related_object_radio_buttons) == 1
 
         # Second update with different related objects
         zarr_path2 = tmp_path / "test2.zarr"
         root2 = zarr.open_group(str(zarr_path2), mode="w")
-        root2.attrs["geff"] = {"related_objects": [{"type": "labels", "path": "seg2"}]}
+        root2.attrs["geff"] = _minimal_geff_attrs(
+            related_objects=[{"type": "labels", "path": "seg2"}]
+        )
         widget.update_root(root2)
 
         # Should have new radio, not old one
@@ -497,9 +515,9 @@ class TestGeffSegmentationWidget:
         # Create zarr group with related object
         zarr_path = tmp_path / "test.zarr"
         root = zarr.open_group(str(zarr_path), mode="w")
-        root.attrs["geff"] = {
-            "related_objects": [{"type": "labels", "path": "segmentation"}]
-        }
+        root.attrs["geff"] = _minimal_geff_attrs(
+            related_objects=[{"type": "labels", "path": "segmentation"}]
+        )
         widget.update_root(root)
 
         # Select the related object radio
@@ -539,9 +557,9 @@ class TestGeffSegmentationWidget:
         zarr_path = tmp_path / "test.zarr"
         # First create root group
         root = zarr.open_group(str(zarr_path / "tracks"), mode="w")
-        root.attrs["geff"] = {
-            "related_objects": [{"type": "labels", "path": "segmentation"}]
-        }
+        root.attrs["geff"] = _minimal_geff_attrs(
+            related_objects=[{"type": "labels", "path": "segmentation"}]
+        )
 
         # Create the expected segmentation path
         seg_path = zarr_path / "tracks" / "segmentation"


### PR DESCRIPTION
**Problem:**
- tracksdata saves segmentation shape in geffmetadata as .extra.tracksdata.shape
- funtracks/motile_tracker save segmentation shape in zarr-metadata as segmentation_shape at the top level (outside the geff metadata)
- in retrospect, the latter is not the smartest design decision, because 1) top-level non-geff metadata doesn't survive round-trips, and 2) it is inconsistent with tracksdata

**Solution:**
This PR removes the segmentation_shape logic, and fully uses the existing tracksdata format of saving the shape in metadata.extra.tracksdata.shape. When reading the shape from the metadata we do a double check for backwards compatibility.

For geffs that are exported from motile_tracker and then imported, it doesn't matter where we save the shape, because that is an internal discussion. But for geffs exported by other tracksdata-based tracking tools (ultrack, hoct, etc.), we are now natively compatible.