### PR TITLE
Benchmark uses separate uvs for base vs main

### DIFF
--- a/.github/workflows/benchmark_pr.py
+++ b/.github/workflows/benchmark_pr.py
@@ -3,7 +3,15 @@
 Usage:
     python benchmark_pr.py <old.json> <new.json> <output.md> [header]
 
-Exits with code 1 if any benchmark regresses by more than REGRESSION_THRESHOLD.
+The table reports mean ± standard deviation for human readability, but the
+pass/fail gate compares the *median*. Median is robust to a single outlier round
+in either direction: `min` is biased down by an accidentally-fast run, `mean` up
+by an unlucky-slow one (a transient OS/GC spike). With >=3 rounds the median
+ignores one such spike, which is what keeps the noisy single-action benchmarks
+from tripping the gate spuriously.
+
+Exits with code 1 if any benchmark's median regresses by more than
+REGRESSION_THRESHOLD percent.
 """
 
 import json
@@ -23,9 +31,21 @@ def load_stats(path):
 
     rows = []
     for d in data["benchmarks"]:
-        rows.append({"Benchmark": d["name"], "mean": d["stats"]["mean"]})
+        s = d["stats"]
+        rows.append(
+            {
+                "Benchmark": d["name"],
+                "median": s["median"],
+                "mean": s["mean"],
+                "stddev": s["stddev"],
+            }
+        )
 
     return commit, pd.DataFrame(rows)
+
+
+def _fmt(mean, std):
+    return f"{mean:.5f} ± {std:.5f}"
 
 
 def _write(out_file, report):
@@ -40,9 +60,13 @@ def make_report(old_path, new_path, out_file, header=None):
     # No baseline available (e.g. the first PR introducing benchmarks, or a run on
     # a base commit that predates the suite). Report HEAD-only numbers and pass.
     if not os.path.exists(old_path) or os.path.getsize(old_path) == 0:
-        df = new_df.rename(columns={"mean": f"Mean (s) HEAD {new_commit}"})
-        df[f"Mean (s) HEAD {new_commit}"] = df[f"Mean (s) HEAD {new_commit}"].map(
-            "{:.5f}".format
+        df = pd.DataFrame(
+            {
+                "Benchmark": new_df["Benchmark"],
+                f"Mean ± SD (s) HEAD {new_commit}": [
+                    _fmt(m, s) for m, s in zip(new_df["mean"], new_df["stddev"])
+                ],
+            }
         )
         report = df.to_markdown(index=False)
         note = "_No baseline found; showing HEAD results only (no comparison)._"
@@ -54,40 +78,36 @@ def make_report(old_path, new_path, out_file, header=None):
 
     old_commit, old_df = load_stats(old_path)
 
-    # Merge on benchmark name
-    df = old_df.merge(new_df, on="Benchmark", suffixes=("_old", "_new"))
-    old = (old_commit,)
-    new = (new_commit,)
+    # Merge on benchmark name (drops benchmarks present on only one side).
+    merged = old_df.merge(new_df, on="Benchmark", suffixes=("_old", "_new"))
 
-    pct_change = 100 * (df["mean_new"] - df["mean_old"]) / df["mean_old"]
-    df["Percent Change"] = pct_change.map("{:+.2f}".format)
+    # Gate on the median (see module docstring).
+    pct_change = (
+        100 * (merged["median_new"] - merged["median_old"]) / merged["median_old"]
+    )
 
-    # Format runtimes
-    df["mean_old"] = df["mean_old"].map("{:.5f}".format)
-    df["mean_new"] = df["mean_new"].map("{:.5f}".format)
-
-    # Change column names to commit ids
-    df = df.rename(
-        columns={
-            "mean_new": f"Mean (s) HEAD {new[0]}",
-            "mean_old": f"Mean (s) BASE {old[0]}",
+    df = pd.DataFrame(
+        {
+            "Benchmark": merged["Benchmark"],
+            f"Mean ± SD (s) BASE {old_commit}": [
+                _fmt(m, s) for m, s in zip(merged["mean_old"], merged["stddev_old"])
+            ],
+            f"Mean ± SD (s) HEAD {new_commit}": [
+                _fmt(m, s) for m, s in zip(merged["mean_new"], merged["stddev_new"])
+            ],
+            "Median Change": pct_change.map("{:+.2f}%".format),
         }
     )
 
     report = df.to_markdown(index=False)
     if header:
         report = f"## {header}\n\n{report}"
+    _write(out_file, report)
 
-    with open(out_file, "w") as f:
-        f.write(report)
-
-    # Print report to logs
-    print(report)  # noqa: T201
-
-    # Fail if any benchmark regressed beyond threshold
+    # Fail if any benchmark's median regressed beyond threshold
     if (pct_change > REGRESSION_THRESHOLD).any():
         print(  # noqa: T201
-            f"\nFAILED: Regression exceeds {REGRESSION_THRESHOLD}% threshold"
+            f"\nFAILED: median regression exceeds {REGRESSION_THRESHOLD}% threshold"
         )
         sys.exit(1)
 

--- a/.github/workflows/benchmark_pr.py
+++ b/.github/workflows/benchmark_pr.py
@@ -64,7 +64,8 @@ def make_report(old_path, new_path, out_file, header=None):
             {
                 "Benchmark": new_df["Benchmark"],
                 f"Mean ± SD (s) HEAD {new_commit}": [
-                    _fmt(m, s) for m, s in zip(new_df["mean"], new_df["stddev"])
+                    _fmt(m, s)
+                    for m, s in zip(new_df["mean"], new_df["stddev"], strict=True)
                 ],
             }
         )
@@ -90,10 +91,12 @@ def make_report(old_path, new_path, out_file, header=None):
         {
             "Benchmark": merged["Benchmark"],
             f"Mean ± SD (s) BASE {old_commit}": [
-                _fmt(m, s) for m, s in zip(merged["mean_old"], merged["stddev_old"])
+                _fmt(m, s)
+                for m, s in zip(merged["mean_old"], merged["stddev_old"], strict=True)
             ],
             f"Mean ± SD (s) HEAD {new_commit}": [
-                _fmt(m, s) for m, s in zip(merged["mean_new"], merged["stddev_new"])
+                _fmt(m, s)
+                for m, s in zip(merged["mean_new"], merged["stddev_new"], strict=True)
             ],
             "Median Change": pct_change.map("{:+.2f}%".format),
         }

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -22,7 +22,9 @@ jobs:
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
     env:
-      # disable resyncing on uv run so `git checkout <base>` keeps the head-synced env
+      # Stop `uv run` from auto-resyncing (which would drop the `testing` group).
+      # Each benchmark step below runs its own explicit `uv sync` after checkout so
+      # base and head are each measured against *their own* locked dependencies.
       UV_NO_SYNC: "1"
 
     steps:
@@ -62,6 +64,14 @@ jobs:
       # essential: CI runners -- especially macOS/Windows -- vary enough machine-to-machine
       # that comparing against a baseline cached from a different run produced spurious
       # regressions larger than the real deltas.
+      #
+      # Each side re-syncs its OWN dependencies after checkout (`uv sync` after `git
+      # checkout`). This is what makes dependency-bump PRs (funtracks/tracksdata/...)
+      # measure the real base-vs-head delta: base runs against base's locked deps and
+      # head against head's. Without the per-checkout sync, base code would run against
+      # head's deps -- an apples-to-oranges comparison that reports fictional regressions
+      # whenever a dependency changes a shared contract. `git checkout -f` discards any
+      # uv.lock churn from the previous sync so the next checkout is clean.
       # Tolerant on purpose: the base commit may predate the benchmark suite, in which
       # case there is no baseline and the report falls back to HEAD-only numbers.
       - name: Run baseline benchmark (same runner)
@@ -69,14 +79,16 @@ jobs:
         uses: aganders3/headless-gui@v2
         with:
           run: |
-            git checkout ${{ github.event.pull_request.base.sha }}
+            git checkout -f ${{ github.event.pull_request.base.sha }}
+            uv sync --no-dev --group testing
             uv run pytest tests/benchmarks -o addopts= --benchmark-json baseline.json
 
       - name: Run benchmark on PR head
         uses: aganders3/headless-gui@v2
         with:
           run: |
-            git checkout ${{ github.event.pull_request.head.sha }}
+            git checkout -f ${{ github.event.pull_request.head.sha }}
+            uv sync --no-dev --group testing
             uv run pytest tests/benchmarks -o addopts= --benchmark-json pr.json
 
       - name: Generate report

--- a/tests/benchmarks/bench_ui_actions.py
+++ b/tests/benchmarks/bench_ui_actions.py
@@ -239,9 +239,7 @@ def test_undo(benchmark, build_app, fresh_tracks):
         tv.delete_node()
         return (tv,), {}
 
-    benchmark.pedantic(
-        lambda tv: tv.undo(), setup=setup, rounds=ROUNDS, iterations=1
-    )
+    benchmark.pedantic(lambda tv: tv.undo(), setup=setup, rounds=ROUNDS, iterations=1)
 
 
 def test_redo(benchmark, build_app, fresh_tracks):
@@ -253,6 +251,4 @@ def test_redo(benchmark, build_app, fresh_tracks):
         tv.undo()
         return (tv,), {}
 
-    benchmark.pedantic(
-        lambda tv: tv.redo(), setup=setup, rounds=ROUNDS, iterations=1
-    )
+    benchmark.pedantic(lambda tv: tv.redo(), setup=setup, rounds=ROUNDS, iterations=1)

--- a/tests/benchmarks/bench_ui_actions.py
+++ b/tests/benchmarks/bench_ui_actions.py
@@ -3,10 +3,11 @@
 Cover the common interactive actions at scale: loading, selection, display-mode
 switching, tree-view rendering, and editing. Each benchmark builds its own app in
 ``setup`` (not timed) and measures a single action with
-``benchmark.pedantic(..., rounds=ROUNDS_FAST, iterations=1)``. Each action triggers a
-full refresh cascade that can take seconds at scale; we average over a few rounds
-(``ROUNDS``) to smooth per-run noise. pytest-benchmark re-runs ``setup`` before
-every round, so mutating benchmarks still start each round from fresh state.
+``benchmark.pedantic(..., rounds=ROUNDS, iterations=1)``. Each action triggers a
+full refresh cascade that can take seconds at scale; we collect a few rounds
+(``ROUNDS``) so the report can gate on the median and ignore a single noisy run.
+pytest-benchmark re-runs ``setup`` before every round, so mutating benchmarks
+still start each round from fresh state.
 
 In CI these run under aganders3/headless-gui (Xvfb-backed GL). They will segfault
 under the ``offscreen`` Qt platform, which lacks a real GL context.
@@ -16,12 +17,14 @@ from __future__ import annotations
 
 from synthetic_data import pick_nodes, tracklet_nodes
 
-# Rounds pytest-benchmark averages each measurement over. The same-runner base/head
-# comparison is what removes machine-to-machine noise; averaging only pays off on the
-# cheap read-only actions (which are also the noisiest). The multi-second editing/bulk
-# actions are stable and setup-heavy, so we run them once to keep CI time down.
-ROUNDS_FAST = 3  # cheap read-only: clicks, lineage, colormap, flip, recolor
-ROUNDS_SLOW = 1  # multi-second editing/bulk actions
+# Rounds pytest-benchmark collects per measurement. The report gates on the *median*
+# across rounds, so >=3 rounds lets a single transient spike be ignored (see
+# benchmark_pr.py). We run everything with 3 rounds for that noise robustness, except
+# the two ~50s bulk operations -- for them the expensive work is in the action or the
+# setup (which pedantic re-runs every round), so 3 rounds would triple an already
+# minutes-long test. Those stay single-shot to keep CI time bounded.
+ROUNDS = 3  # default: enough samples for a robust median
+ROUNDS_BULK = 1  # ~50s bulk delete / its undo -- too expensive to repeat
 
 # ----------------------------------------------------------------------------------
 # Loading
@@ -42,7 +45,7 @@ def test_add_tracks(benchmark, make_napari_viewer, shared_tracks):
     benchmark.pedantic(
         lambda tv, tracks: tv.tracks_list.add_tracks(tracks, "synthetic"),
         setup=setup,
-        rounds=ROUNDS_SLOW,
+        rounds=ROUNDS,
         iterations=1,
     )
 
@@ -60,7 +63,7 @@ def test_click_node_treeview(benchmark, build_app, shared_tracks):
     benchmark.pedantic(
         lambda tree, node: tree.tree_widget.node_clicked.emit(node, False),
         setup=setup,
-        rounds=ROUNDS_FAST,
+        rounds=ROUNDS,
         iterations=1,
     )
 
@@ -73,7 +76,7 @@ def test_click_node_canvas(benchmark, build_app, shared_tracks):
     benchmark.pedantic(
         lambda tv, node: tv.selected_nodes.add(node, False),
         setup=setup,
-        rounds=ROUNDS_FAST,
+        rounds=ROUNDS,
         iterations=1,
     )
 
@@ -90,7 +93,7 @@ def test_set_display_mode_lineage(benchmark, build_app, shared_tracks):
     benchmark.pedantic(
         lambda tv: tv.set_display_mode("lineage"),
         setup=setup,
-        rounds=ROUNDS_FAST,
+        rounds=ROUNDS,
         iterations=1,
     )
 
@@ -106,7 +109,7 @@ def test_tree_flip_axes(benchmark, build_app, shared_tracks):
         return (tree,), {}
 
     benchmark.pedantic(
-        lambda tree: tree.flip_axes(), setup=setup, rounds=ROUNDS_FAST, iterations=1
+        lambda tree: tree.flip_axes(), setup=setup, rounds=ROUNDS, iterations=1
     )
 
 
@@ -120,7 +123,7 @@ def test_tree_feature_recolor(benchmark, build_app, shared_tracks):
     benchmark.pedantic(
         lambda tree: tree.toggle_feature_mode(),
         setup=setup,
-        rounds=ROUNDS_FAST,
+        rounds=ROUNDS,
         iterations=1,
     )
 
@@ -135,7 +138,7 @@ def test_label_colormap_rebuild(benchmark, build_app, shared_tracks):
     benchmark.pedantic(
         lambda seg: seg._get_colormap(),
         setup=setup,
-        rounds=ROUNDS_FAST,
+        rounds=ROUNDS,
         iterations=1,
     )
 
@@ -153,7 +156,7 @@ def test_delete_node(benchmark, build_app, fresh_tracks):
         return (tv,), {}
 
     benchmark.pedantic(
-        lambda tv: tv.delete_node(), setup=setup, rounds=ROUNDS_SLOW, iterations=1
+        lambda tv: tv.delete_node(), setup=setup, rounds=ROUNDS, iterations=1
     )
 
 
@@ -173,7 +176,7 @@ def test_delete_nodes_bulk(benchmark, build_app, fresh_tracks):
         return (tv,), {}
 
     benchmark.pedantic(
-        lambda tv: tv.delete_node(), setup=setup, rounds=ROUNDS_SLOW, iterations=1
+        lambda tv: tv.delete_node(), setup=setup, rounds=ROUNDS_BULK, iterations=1
     )
 
 
@@ -189,7 +192,7 @@ def test_undo_bulk_delete(benchmark, build_app, fresh_tracks):
         return (tv,), {}
 
     benchmark.pedantic(
-        lambda tv: tv.undo(), setup=setup, rounds=ROUNDS_SLOW, iterations=1
+        lambda tv: tv.undo(), setup=setup, rounds=ROUNDS_BULK, iterations=1
     )
 
 
@@ -203,7 +206,7 @@ def test_delete_edge(benchmark, build_app, fresh_tracks):
         return (tv,), {}
 
     benchmark.pedantic(
-        lambda tv: tv.delete_edge(), setup=setup, rounds=ROUNDS_SLOW, iterations=1
+        lambda tv: tv.delete_edge(), setup=setup, rounds=ROUNDS, iterations=1
     )
 
 
@@ -224,7 +227,7 @@ def test_create_edge(benchmark, build_app, fresh_tracks):
         return (tv,), {}
 
     benchmark.pedantic(
-        lambda tv: tv.create_edge(), setup=setup, rounds=ROUNDS_SLOW, iterations=1
+        lambda tv: tv.create_edge(), setup=setup, rounds=ROUNDS, iterations=1
     )
 
 
@@ -237,7 +240,7 @@ def test_undo(benchmark, build_app, fresh_tracks):
         return (tv,), {}
 
     benchmark.pedantic(
-        lambda tv: tv.undo(), setup=setup, rounds=ROUNDS_SLOW, iterations=1
+        lambda tv: tv.undo(), setup=setup, rounds=ROUNDS, iterations=1
     )
 
 
@@ -251,5 +254,5 @@ def test_redo(benchmark, build_app, fresh_tracks):
         return (tv,), {}
 
     benchmark.pedantic(
-        lambda tv: tv.redo(), setup=setup, rounds=ROUNDS_SLOW, iterations=1
+        lambda tv: tv.redo(), setup=setup, rounds=ROUNDS, iterations=1
     )


### PR DESCRIPTION
Three benchmark changes:
 
- Previously, the benchmark code used the same `uv` environment to compare `main` to `branch`, which fails when the `branch` updates a dependency (what often happens with funtracks/tracksdata updates)
- run more benchmarks 3 times, to prevent outliers/noise from failing the tests
- report mean+std in benchmark result table