### PR TITLE
Optimize ortho view integration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies =[
     "dask[array]>=2021.10.0",
     "fonticon-fontawesome6>=6,<7",
     "pyqtgraph>=0.13,<1",
-    "napari-orthogonal-views>=0.2.3",
+    "napari-orthogonal-views @ git+https://github.com/AnniekStok/napari-orthogonal-views.git@refs/pull/21/head",
     "lxml_html_clean>=0.4,<1",
     "zarr>=2.18.7,<4",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies =[
     "dask[array]>=2021.10.0",
     "fonticon-fontawesome6>=6,<7",
     "pyqtgraph>=0.13,<1",
-    "napari-orthogonal-views @ git+https://github.com/AnniekStok/napari-orthogonal-views.git@refs/pull/21/head",
+    "napari-orthogonal-views>=0.4.0",
     "lxml_html_clean>=0.4,<1",
     "zarr>=2.18.7,<4",
 ]

--- a/src/motile_tracker/data_views/views/layers/track_points.py
+++ b/src/motile_tracker/data_views/views/layers/track_points.py
@@ -347,23 +347,30 @@ class TrackPoints(ZOnlyPoints):
             self.shown[:] = False
             self.shown[indices] = True
 
-        # set border color for selected item
-        self.border_color = [1, 1, 1, 1]
-        self.size = self.default_size
+        n_points = len(self.data)
+        if n_points == 0:
+            # nothing to style, and napari warns when assigning empty color arrays
+            self.refresh()
+            return
+
+        # Set border color and size for the selected items. Both are built up first and
+        # then assigned once, because every assignment emits an event that the orthogonal
+        # views (if present) answer by re-slicing their copy of this layer.
+        border_colors = np.tile([1.0, 1.0, 1.0, 1.0], (n_points, 1))
+        sizes = np.full(n_points, self.default_size)
+        selected_size = math.ceil(self.default_size + 0.3 * self.default_size)
         for node in self.tracks_viewer.selected_nodes:
             index = self.node_index_dict.get(node, None)
             if index is not None:
-                self.border_color[index] = (
+                border_colors[index] = (
                     0,
                     1,
                     1,
                     1,
                 )
-                self.size[index] = math.ceil(
-                    self.default_size + 0.3 * self.default_size
-                )
+                sizes[index] = selected_size
 
-        # emit the event to trigger update in orthogonal views
-        self.border_color = self.border_color
-        self.size = self.size
+        # size first: the orthogonal views read it when the border color event arrives
+        self.size = sizes
+        self.border_color = border_colors
         self.refresh()

--- a/src/motile_tracker/data_views/views/ortho_views.py
+++ b/src/motile_tracker/data_views/views/ortho_views.py
@@ -2,17 +2,18 @@ import inspect
 from collections.abc import Callable
 from typing import Any
 
-import napari_orthogonal_views.ortho_view_widget as ov_widget
 import numpy as np
 from napari import Viewer
 from napari.layers import Labels, Layer, Points, Shapes
 from napari.utils.colormaps import DirectLabelColormap
 from napari.utils.events import Event
 from napari.utils.notifications import show_info
+from napari_orthogonal_views.layer_sync_hooks import sync_labels_paint
 from napari_orthogonal_views.ortho_view_manager import (  # noqa
     OrthoViewManager,
     _get_manager,
 )
+from napari_orthogonal_views.ortho_view_widget import ViewerModelContainer
 
 from motile_tracker.data_views.keybindings_config import KEYMAP, bind_keymap
 from motile_tracker.data_views.views.layers.click_utils import (
@@ -27,7 +28,8 @@ from motile_tracker.data_views.views.layers.track_labels import TrackLabels
 from motile_tracker.data_views.views.layers.track_points import TrackPoints
 
 
-# redefinition of copy_layer function
+# How the tracking layers are copied into the orthogonal views. Installed with
+# OrthoViewManager.set_copy_layer.
 def copy_layer(layer: Layer, name: str = ""):
     if isinstance(
         layer, TrackGraph
@@ -67,9 +69,6 @@ def copy_layer(layer: Layer, name: str = ""):
     res_layer.metadata["viewer_name"] = name
     return res_layer
 
-
-ov_widget.copy_layer = copy_layer  # replace the copy layer with the customized version
-# defined here
 
 # Define custom sync_filters. By default, all properties are synced forwards and backwards
 # between the original layer and its derived copy. However, for Tracks Layers we need
@@ -124,15 +123,22 @@ sync_filters = {
 
 
 # Define special functions to allow specific behavior on special layer types (TrackLabels,
-# and TrackPoints)
+# and TrackPoints). They follow the hook contract of napari-orthogonal-views: called once
+# per layer per orthogonal view as hook(container, orig_layer, copied_layer), returning
+# whatever has to be undone when the layer or the views go away. None of these need the
+# container, because they hand the work to the original layer rather than syncing it
+# themselves, so they take it as `_container`.
 #
 def point_data_hook(
-    orig_layer: TrackPoints, copied_layer: ZOnlyPoints
+    _container: ViewerModelContainer,
+    orig_layer: TrackPoints,
+    copied_layer: ZOnlyPoints,
 ) -> list[tuple[Any, Callable]]:
     """Hook to connect to sync points data and visualization between original and copied
     Points layers.
 
     Args:
+        _container (ViewerModelContainer): owner of the copied layer; unused here.
         orig_layer (TrackPoints): TracksLabels layer from which the copied layer is
             derived.
         copied_layer (ZOnlyPoints): ZOnlyPoints equivalent of the TracksPoints layer.
@@ -217,12 +223,15 @@ def point_data_hook(
 
 
 def paint_event_hook(
-    orig_layer: TrackLabels, copied_layer: Labels
+    _container: ViewerModelContainer,
+    orig_layer: TrackLabels,
+    copied_layer: Labels,
 ) -> list[tuple[Any, Callable]]:
     """Hook to connect to paint events and process them on the original TracksLabels
     layer.
 
     Args:
+        _container (ViewerModelContainer): owner of the copied layer; unused here.
         orig_layer (TrackLabels): TracksLabels layer from which the copied layer is
             derived.
         copied_layer (Labels): Labels equivalent of the TracksLabels layer. Instead of
@@ -310,7 +319,9 @@ def make_own_colormap(orig_layer: TrackLabels, copied_layer: Labels) -> None:
 
 
 def colormap_hook(
-    orig_layer: TrackLabels, copied_layer: Labels
+    _container: ViewerModelContainer,
+    orig_layer: TrackLabels,
+    copied_layer: Labels,
 ) -> list[tuple[Any, Callable]]:
     """Hook to sync colormap changes from the original TrackLabels layer to the copied
     layers. We need a hook for the special case in which one of the views is showing a 3D
@@ -370,14 +381,42 @@ def colormap_hook(
     return [(orig_layer.events.colormap, update_colormap_wrapper)]
 
 
+def labels_paint_hook(
+    container: ViewerModelContainer,
+    orig_layer: Labels,
+    copied_layer: Labels,
+) -> list[tuple[Any, Callable]] | None:
+    """Replacement for the built-in paint syncing, for TrackLabels layers only. This is to
+    ensure that normal Labels layers keep the default behavior, but TrackLabels layers
+    skip this because they are handled via our custom paint_event_hook.
+
+    Args:
+        container (ViewerModelContainer): owner of the copied layer.
+        orig_layer (Labels): the layer on the main viewer.
+        copied_layer (Labels): its counterpart in the orthogonal view.
+
+    Returns:
+        list[tuple[Any, Callable]] | None: connections made for a non-TrackLabels layer,
+            or None for a TrackLabels layer, where motile syncs the paint itself.
+    """
+
+    if isinstance(orig_layer, TrackLabels):
+        return None
+
+    return sync_labels_paint(container, orig_layer, copied_layer)
+
+
 def track_layers_hook(
-    orig_layer: TrackLabels | TrackPoints, copied_layer: Labels | ZOnlyPoints
+    _container: ViewerModelContainer,
+    orig_layer: TrackLabels | TrackPoints,
+    copied_layer: Labels | ZOnlyPoints,
 ) -> None:
     """Hook to capture click events on TrackLabels and TrackPoints derived Labels and
     ZOnlyPoints layers, and forward them to their original layer. Also, register key binds
     for view mode, undo & redo to copied layer, that call functions on the original layer.
 
     Args:
+        _container (ViewerModelContainer): owner of the copied layer; unused here.
         orig_layer (TrackLabels | TrackPoints): TracksLabels or TrackPoints layer from
             which the copied layer is derived.
         copied_layer (Labels | ZOnlyPoints): Labels or ZOnlyPoints equivalent of the TracksLabels
@@ -423,10 +462,28 @@ def initialize_ortho_views(viewer: Viewer) -> OrthoViewManager:
     """
 
     orth_view_manager = _get_manager(viewer)
-    orth_view_manager.register_layer_hook((TrackLabels, TrackPoints), track_layers_hook)
-    orth_view_manager.register_layer_hook((TrackLabels), paint_event_hook)
-    orth_view_manager.register_layer_hook((TrackPoints), point_data_hook)
-    orth_view_manager.register_layer_hook((TrackLabels), colormap_hook)
+
+    # how the tracking layers are shown in the orthogonal views
+    orth_view_manager.set_copy_layer(copy_layer)
+
+    # what they have to do beyond the generic property syncing
+    orth_view_manager.register_layer_hook(
+        (TrackLabels, TrackPoints), track_layers_hook, name="TrackLayer_clicks_and_keys"
+    )
+    orth_view_manager.register_layer_hook(
+        TrackLabels, paint_event_hook, name="TrackLabels_paint"
+    )
+    orth_view_manager.register_layer_hook(
+        TrackPoints, point_data_hook, name="TrackPoints_point_data"
+    )
+    orth_view_manager.register_layer_hook(
+        TrackLabels, colormap_hook, name="TrackLabels_colormap"
+    )
+
+    # Narrow the built-in paint syncing to normal Labels layers (so that TrackLabels do
+    # not run this on top of their own paint_event_hook)
+    orth_view_manager.set_layer_hook("labels_paint", labels_paint_hook)
+
     orth_view_manager.set_sync_filters(sync_filters)
     orth_view_manager.activate_checkboxes = True
 

--- a/src/motile_tracker/data_views/views/ortho_views.py
+++ b/src/motile_tracker/data_views/views/ortho_views.py
@@ -97,6 +97,7 @@ sync_filters = {
             "data",
             "size",
             "current_size",
+            "properties",  # we sync features but no need to sync properties as well
         },  # we will sync data separately on TrackPoints as we
         # need finer control
         "reverse_exclude": set(get_property_names_from_class(Points))

--- a/src/motile_tracker/data_views/views/ortho_views.py
+++ b/src/motile_tracker/data_views/views/ortho_views.py
@@ -1,4 +1,6 @@
 import inspect
+from collections.abc import Callable
+from typing import Any
 
 import napari_orthogonal_views.ortho_view_widget as ov_widget
 from napari import Viewer
@@ -117,7 +119,9 @@ sync_filters = {
 # Define special functions to allow specific behavior on special layer types (TrackLabels,
 # and TrackPoints)
 #
-def point_data_hook(orig_layer: TrackPoints, copied_layer: ZOnlyPoints) -> None:
+def point_data_hook(
+    orig_layer: TrackPoints, copied_layer: ZOnlyPoints
+) -> list[tuple[Any, Callable]]:
     """Hook to connect to sync points data and visualization between original and copied
     Points layers.
 
@@ -125,6 +129,10 @@ def point_data_hook(orig_layer: TrackPoints, copied_layer: ZOnlyPoints) -> None:
         orig_layer (TrackPoints): TracksLabels layer from which the copied layer is
             derived.
         copied_layer (ZOnlyPoints): ZOnlyPoints equivalent of the TracksPoints layer.
+
+    Returns:
+        list[tuple[Any, Callable]]: the (signal, handler) pairs connected here, so the
+            orthoviews can disconnect them again when the layer or the views go away.
     """
 
     # Sync the shown points and their size, as it is not synced by default. We bind to the
@@ -144,6 +152,7 @@ def point_data_hook(orig_layer: TrackPoints, copied_layer: ZOnlyPoints) -> None:
         return sync_shown_points(orig_layer, copied_layer)
 
     orig_layer.events.border_color.connect(shown_points_wrapper)
+    connections = [(orig_layer.events.border_color, shown_points_wrapper)]
 
     # Receive data updates from the original layer
     def receive_data(orig_layer: TrackPoints, copied_layer: ZOnlyPoints) -> None:
@@ -157,6 +166,7 @@ def point_data_hook(orig_layer: TrackPoints, copied_layer: ZOnlyPoints) -> None:
         return receive_data(orig_layer, copied_layer)
 
     orig_layer.data_updated.connect(receive_data_wrapper)
+    connections.append((orig_layer.data_updated, receive_data_wrapper))
 
     # Sync the event that is emitted when a point is moved or deleted. We need to capture
     # it on the original layer to process it there, and potentially undo it if it was an
@@ -187,9 +197,14 @@ def point_data_hook(orig_layer: TrackPoints, copied_layer: ZOnlyPoints) -> None:
 
     copied_layer._sync_data_wrapper = sync_data_wrapper
     copied_layer.events.data.connect(sync_data_wrapper)
+    connections.append((copied_layer.events.data, sync_data_wrapper))
+
+    return connections
 
 
-def paint_event_hook(orig_layer: TrackLabels, copied_layer: Labels) -> None:
+def paint_event_hook(
+    orig_layer: TrackLabels, copied_layer: Labels
+) -> list[tuple[Any, Callable]]:
     """Hook to connect to paint events and process them on the original TracksLabels
     layer.
 
@@ -199,6 +214,9 @@ def paint_event_hook(orig_layer: TrackLabels, copied_layer: Labels) -> None:
         copied_layer (Labels): Labels equivalent of the TracksLabels layer. Instead of
             processing paint actions on this copy, we want to send them to the original
             layer and process them there.
+
+    Returns:
+        list[tuple[Any, Callable]]: the (signal, handler) pairs connected here.
     """
 
     def sync_paint(orig_layer: TrackLabels, copied_layer: Labels, event: Event):
@@ -218,8 +236,12 @@ def paint_event_hook(orig_layer: TrackLabels, copied_layer: Labels) -> None:
 
     copied_layer.events.paint.connect(paint_wrapper)
 
+    return [(copied_layer.events.paint, paint_wrapper)]
 
-def colormap_hook(orig_layer: TrackLabels, copied_layer: Labels) -> None:
+
+def colormap_hook(
+    orig_layer: TrackLabels, copied_layer: Labels
+) -> list[tuple[Any, Callable]]:
     """Hook to sync colormap changes from the original TrackLabels layer to the copied
     layers. We need a hook for the special case in which one of the views is showing a 3D
     rendering in combination with partially filled contour labels. Since contours are not
@@ -229,6 +251,11 @@ def colormap_hook(orig_layer: TrackLabels, copied_layer: Labels) -> None:
         orig_layer (TrackLabels): TracksLabels layer from which the copied layer is
             derived.
         copied_layer (ContourLabels): ContourLabels equivalent of the TracksLabels layer.
+
+    Returns:
+        list[tuple[Any, Callable]]: the (signal, handler) pairs connected here. This one
+            matters most: the handler rebuilds the colormap of the copied layer, so if it
+            outlives the copy it keeps doing that work for a layer nobody sees.
     """
 
     def sync_colormap(orig_layer: TrackLabels, copied_layer: Labels, event: Event):
@@ -254,6 +281,8 @@ def colormap_hook(orig_layer: TrackLabels, copied_layer: Labels) -> None:
 
     orig_layer.events.colormap.connect(update_colormap_wrapper)
 
+    return [(orig_layer.events.colormap, update_colormap_wrapper)]
+
 
 def track_layers_hook(
     orig_layer: TrackLabels | TrackPoints, copied_layer: Labels | ZOnlyPoints
@@ -267,6 +296,9 @@ def track_layers_hook(
             which the copied layer is derived.
         copied_layer (Labels | ZOnlyPoints): Labels or ZOnlyPoints equivalent of the TracksLabels
             or TrackPoints layer.
+
+    Nothing is returned because everything connected here lives on the copied layer,
+    which is discarded together with the orthogonal view.
     """
 
     # define the click behavior the layer should respond to

--- a/src/motile_tracker/data_views/views/ortho_views.py
+++ b/src/motile_tracker/data_views/views/ortho_views.py
@@ -3,6 +3,7 @@ from collections.abc import Callable
 from typing import Any
 
 import napari_orthogonal_views.ortho_view_widget as ov_widget
+import numpy as np
 from napari import Viewer
 from napari.layers import Labels, Layer, Points, Shapes
 from napari.utils.colormaps import DirectLabelColormap
@@ -239,6 +240,62 @@ def paint_event_hook(
     return [(copied_layer.events.paint, paint_wrapper)]
 
 
+def needs_own_colormap(orig_layer: TrackLabels, copied_layer: Labels) -> bool:
+    """Check whether the copied layer needs a colormap separate from the original's.
+
+    It only does when the two disagree about the background opacity, which happens when
+    contours are on and exactly one of the two views renders in 3D: contours are not
+    rendered in 3D, so there the labels are shown filled and the background is hidden
+    instead (see colormap_hook). In every other case the colors are identical and the
+    colormap object can simply be shared.
+
+    Args:
+        orig_layer (TrackLabels): TrackLabels layer from which the copy is derived.
+        copied_layer (ContourLabels): ContourLabels equivalent of the TrackLabels layer.
+
+    Returns:
+        bool: True if the copied layer needs a color dict of its own.
+    """
+
+    if orig_layer.contour == 0:
+        return False
+    return (orig_layer._slice.slice_input.ndisplay == 3) != (
+        copied_layer._slice.slice_input.ndisplay == 3
+    )
+
+
+def make_own_colormap(orig_layer: TrackLabels, copied_layer: Labels) -> None:
+    """Give the copied layer a color dict of its own, holding the original's colors.
+
+    The colors are copied into the existing dict when the copy already has one for the
+    same labels, because building a new DirectLabelColormap validates every color again.
+    A new one is only constructed when the labels changed, or when the copy is still
+    sharing the original's colormap (see colormap_hook).
+
+    Args:
+        orig_layer (TrackLabels): TrackLabels layer from which the copy is derived.
+        copied_layer (ContourLabels): ContourLabels equivalent of the TrackLabels layer.
+    """
+
+    source_colors = orig_layer.colormap.color_dict
+    target_colors = copied_layer.colormap.color_dict
+
+    if (
+        copied_layer.colormap is orig_layer.colormap
+        or target_colors.keys() != source_colors.keys()
+    ):
+        copied_layer.colormap = DirectLabelColormap(
+            color_dict={
+                label: np.array(color, copy=True)
+                for label, color in source_colors.items()
+            }
+        )
+        return
+
+    for label, color in source_colors.items():
+        target_colors[label][:] = color
+
+
 def colormap_hook(
     orig_layer: TrackLabels, copied_layer: Labels
 ) -> list[tuple[Any, Callable]]:
@@ -246,6 +303,11 @@ def colormap_hook(
     layers. We need a hook for the special case in which one of the views is showing a 3D
     rendering in combination with partially filled contour labels. Since contours are not
     rendered in 3D, we want to display the non-filled labels with full opacity instead.
+
+    That special case is the only one in which the copy needs a colormap of its own; the
+    rest of the time both views show identical colors and share a single colormap object,
+    which keeps this hook off the critical path of every selection and every paint (see
+    needs_own_colormap and make_own_colormap).
 
     Args:
         orig_layer (TrackLabels): TracksLabels layer from which the copied layer is
@@ -263,10 +325,21 @@ def colormap_hook(
         ContourLabels instance. Check the slice ndisplay and contour settings to adjust
         background opacity accordingly."""
 
-        copied_layer.colormap = DirectLabelColormap(
-            color_dict=orig_layer.colormap.color_dict
-        )
-        if copied_layer._slice.slice_input.ndisplay == 3 and orig_layer.contour > 0:
+        if not needs_own_colormap(orig_layer, copied_layer):
+            # Both views want exactly the same colors, so let them share the very same
+            # colormap object instead of giving the copy one of its own: constructing a
+            # DirectLabelColormap re-validates every color (~0.2s for a 37k label graph,
+            # per view, on every colormap event). Opacity changes the original makes in
+            # place are then visible here immediately, and only the texture is rebuilt.
+            if copied_layer.colormap is orig_layer.colormap:
+                copied_layer.refresh_colormap()
+            else:
+                copied_layer.colormap = orig_layer.colormap
+            return
+
+        # The copy needs its own color dict, because its background opacity differs.
+        make_own_colormap(orig_layer, copied_layer)
+        if copied_layer._slice.slice_input.ndisplay == 3:
             copied_layer.set_opacity(orig_layer.background, 0)
         else:
             copied_layer.set_opacity(

--- a/src/motile_tracker/data_views/views/ortho_views.py
+++ b/src/motile_tracker/data_views/views/ortho_views.py
@@ -13,7 +13,6 @@ from napari_orthogonal_views.ortho_view_manager import (  # noqa
     OrthoViewManager,
     _get_manager,
 )
-from napari_orthogonal_views.ortho_view_widget import ViewerModelContainer
 
 from motile_tracker.data_views.keybindings_config import KEYMAP, bind_keymap
 from motile_tracker.data_views.views.layers.click_utils import (
@@ -124,13 +123,9 @@ sync_filters = {
 
 # Define special functions to allow specific behavior on special layer types (TrackLabels,
 # and TrackPoints). They follow the hook contract of napari-orthogonal-views: called once
-# per layer per orthogonal view as hook(container, orig_layer, copied_layer), returning
-# whatever has to be undone when the layer or the views go away. None of these need the
-# container, because they hand the work to the original layer rather than syncing it
-# themselves, so they take it as `_container`.
-#
+# per layer per orthogonal view as hook(orig_layer, copied_layer), returning whatever has
+# to be undone when the layer or the views go away.
 def point_data_hook(
-    _container: ViewerModelContainer,
     orig_layer: TrackPoints,
     copied_layer: ZOnlyPoints,
 ) -> list[tuple[Any, Callable]]:
@@ -138,7 +133,6 @@ def point_data_hook(
     Points layers.
 
     Args:
-        _container (ViewerModelContainer): owner of the copied layer; unused here.
         orig_layer (TrackPoints): TracksLabels layer from which the copied layer is
             derived.
         copied_layer (ZOnlyPoints): ZOnlyPoints equivalent of the TracksPoints layer.
@@ -223,7 +217,6 @@ def point_data_hook(
 
 
 def paint_event_hook(
-    _container: ViewerModelContainer,
     orig_layer: TrackLabels,
     copied_layer: Labels,
 ) -> list[tuple[Any, Callable]]:
@@ -231,7 +224,6 @@ def paint_event_hook(
     layer.
 
     Args:
-        _container (ViewerModelContainer): owner of the copied layer; unused here.
         orig_layer (TrackLabels): TracksLabels layer from which the copied layer is
             derived.
         copied_layer (Labels): Labels equivalent of the TracksLabels layer. Instead of
@@ -319,7 +311,6 @@ def make_own_colormap(orig_layer: TrackLabels, copied_layer: Labels) -> None:
 
 
 def colormap_hook(
-    _container: ViewerModelContainer,
     orig_layer: TrackLabels,
     copied_layer: Labels,
 ) -> list[tuple[Any, Callable]]:
@@ -382,7 +373,6 @@ def colormap_hook(
 
 
 def labels_paint_hook(
-    container: ViewerModelContainer,
     orig_layer: Labels,
     copied_layer: Labels,
 ) -> list[tuple[Any, Callable]] | None:
@@ -391,7 +381,6 @@ def labels_paint_hook(
     skip this because they are handled via our custom paint_event_hook.
 
     Args:
-        container (ViewerModelContainer): owner of the copied layer.
         orig_layer (Labels): the layer on the main viewer.
         copied_layer (Labels): its counterpart in the orthogonal view.
 
@@ -403,11 +392,10 @@ def labels_paint_hook(
     if isinstance(orig_layer, TrackLabels):
         return None
 
-    return sync_labels_paint(container, orig_layer, copied_layer)
+    return sync_labels_paint(orig_layer, copied_layer)
 
 
 def track_layers_hook(
-    _container: ViewerModelContainer,
     orig_layer: TrackLabels | TrackPoints,
     copied_layer: Labels | ZOnlyPoints,
 ) -> None:
@@ -416,7 +404,6 @@ def track_layers_hook(
     for view mode, undo & redo to copied layer, that call functions on the original layer.
 
     Args:
-        _container (ViewerModelContainer): owner of the copied layer; unused here.
         orig_layer (TrackLabels | TrackPoints): TracksLabels or TrackPoints layer from
             which the copied layer is derived.
         copied_layer (Labels | ZOnlyPoints): Labels or ZOnlyPoints equivalent of the TracksLabels

--- a/src/motile_tracker/data_views/views/ortho_views.py
+++ b/src/motile_tracker/data_views/views/ortho_views.py
@@ -55,7 +55,12 @@ def copy_layer(layer: Layer, name: str = ""):
         res_layer = ZOnlyPoints(
             data=layer.data,
             name=layer.name,
+            size=layer.size,  # these are not synced, so copy these properties here to set
+            shown=layer.shown,  # the initial size and shown properties correctly.
         )
+        # points added in an orthogonal view are created at current_size, which is not
+        # synced either, so start it at the size the tracks are drawn with
+        res_layer.current_size = layer.default_size
     else:
         res_layer = Layer.create(*layer.as_layer_data_tuple())
 

--- a/src/motile_tracker/data_views/views/ortho_views.py
+++ b/src/motile_tracker/data_views/views/ortho_views.py
@@ -141,9 +141,16 @@ def point_data_hook(
     # size on the TrackPoints layer.
     def sync_shown_points(orig_layer: TrackPoints, copied_layer: ZOnlyPoints) -> None:
         """Sync the visible points between original TrackPoints layer and Points layers
-        in ViewerModel instances (this is not a synced property)"""
+        in ViewerModel instances (this is not a synced property).
 
-        with copied_layer.events.blocker_all():
+        Both setters re-slice the copied layer on their own, so their refreshes are
+        blocked and a single one is done afterwards instead.
+        """
+
+        if len(copied_layer.data) != len(orig_layer.data):
+            return  # data update still on its way; it syncs these as well
+
+        with copied_layer.events.blocker_all(), copied_layer._block_refresh():
             copied_layer.size = orig_layer.size
             copied_layer.shown = orig_layer.shown
 

--- a/src/motile_tracker/data_views/views/ortho_views.py
+++ b/src/motile_tracker/data_views/views/ortho_views.py
@@ -284,7 +284,7 @@ def make_own_colormap(orig_layer: TrackLabels, copied_layer: Labels) -> None:
     The colors are copied into the existing dict when the copy already has one for the
     same labels, because building a new DirectLabelColormap validates every color again.
     A new one is only constructed when the labels changed, or when the copy is still
-    sharing the original's colormap (see colormap_hook).
+    sharing the original's colormap.
 
     Args:
         orig_layer (TrackLabels): TrackLabels layer from which the copy is derived.
@@ -320,9 +320,7 @@ def colormap_hook(
     rendered in 3D, we want to display the non-filled labels with full opacity instead.
 
     That special case is the only one in which the copy needs a colormap of its own; the
-    rest of the time both views show identical colors and share a single colormap object,
-    which keeps this hook off the critical path of every selection and every paint (see
-    needs_own_colormap and make_own_colormap).
+    rest of the time both views show identical colors and share a single colormap object.
 
     Args:
         orig_layer (TrackLabels): TracksLabels layer from which the copied layer is
@@ -330,9 +328,8 @@ def colormap_hook(
         copied_layer (ContourLabels): ContourLabels equivalent of the TracksLabels layer.
 
     Returns:
-        list[tuple[Any, Callable]]: the (signal, handler) pairs connected here. This one
-            matters most: the handler rebuilds the colormap of the copied layer, so if it
-            outlives the copy it keeps doing that work for a layer nobody sees.
+        list[tuple[Any, Callable]]: the (signal, handler) pairs connected here, so they
+        can be cleaned up when the layer or the views go away.
     """
 
     def sync_colormap(orig_layer: TrackLabels, copied_layer: Labels, event: Event):
@@ -341,11 +338,10 @@ def colormap_hook(
         background opacity accordingly."""
 
         if not needs_own_colormap(orig_layer, copied_layer):
-            # Both views want exactly the same colors, so let them share the very same
-            # colormap object instead of giving the copy one of its own: constructing a
-            # DirectLabelColormap re-validates every color (~0.2s for a 37k label graph,
-            # per view, on every colormap event). Opacity changes the original makes in
-            # place are then visible here immediately, and only the texture is rebuilt.
+            # Both views want exactly the same colors, so they can share the same
+            # colormap object instead of giving the copy one of its own. Opacity changes
+            # the original makes in place are visible here immediately, and only the
+            # texture is rebuilt.
             if copied_layer.colormap is orig_layer.colormap:
                 copied_layer.refresh_colormap()
             else:
@@ -386,7 +382,7 @@ def labels_paint_hook(
 
     Returns:
         list[tuple[Any, Callable]] | None: connections made for a non-TrackLabels layer,
-            or None for a TrackLabels layer, where motile syncs the paint itself.
+            or None for a TrackLabels layer (handled separately).
     """
 
     if isinstance(orig_layer, TrackLabels):

--- a/tests/data_views/test_ortho_views.py
+++ b/tests/data_views/test_ortho_views.py
@@ -3,7 +3,10 @@ import pytest
 from napari.layers import Labels, Points
 from napari_orthogonal_views.ortho_view_widget import OrthoViewWidget
 
-from motile_tracker.data_views.views.layers.track_labels import TrackLabels
+from motile_tracker.data_views.views.layers.track_labels import (
+    TrackLabels,
+    new_label,
+)
 from motile_tracker.data_views.views.layers.track_points import TrackPoints
 from motile_tracker.data_views.views.ortho_views import (
     initialize_ortho_views,
@@ -111,6 +114,86 @@ def n_slots(signal):
 
     callbacks = getattr(signal, "callbacks", None)
     return len(callbacks) if callbacks is not None else len(signal)
+
+
+def assert_same_colors(copied_layer, orig_layer, tag):
+    """Assert that both layers show every label in exactly the same color."""
+
+    copied_colors = copied_layer.colormap.color_dict
+    orig_colors = orig_layer.colormap.color_dict
+    assert copied_colors.keys() == orig_colors.keys(), f"{tag}: different labels"
+    for label, color in orig_colors.items():
+        assert np.allclose(copied_colors[label], color), f"{tag}: label {label} differs"
+
+
+def test_colormap_shared_with_ortho_views(
+    viewer, qtbot, solution_tracks_3d_with_division
+):
+    """The copied layers show the same colors as the original, and share its colormap.
+
+    Building a DirectLabelColormap validates every color again, which is expensive for
+    a large graph and happened per view on every colormap event. The copies only need a
+    colormap of their own when their background opacity differs from the original's,
+    which is the 3D + contours case.
+    """
+
+    m = initialize_ortho_views(viewer)
+    tracks_viewer = TracksViewer.get_instance(viewer)
+    tracks_viewer.update_tracks(tracks=solution_tracks_3d_with_division, name="test")
+    m.show()
+    qtbot.waitUntil(lambda: m.is_shown(), timeout=1000)
+
+    seg_layer = tracks_viewer.tracking_layers.seg_layer
+    copies = [
+        widget.vm_container.viewer_model.layers[seg_layer.name]
+        for widget in (m.right_widget, m.bottom_widget)
+    ]
+    nodes = tracks_viewer.tracks.graph.node_ids()
+
+    def check_shared(tag):
+        for copied_layer in copies:
+            assert_same_colors(copied_layer, seg_layer, tag)
+            assert copied_layer.colormap is seg_layer.colormap, f"{tag}: not shared"
+
+    check_shared("initial")
+
+    tracks_viewer.selected_nodes.add(nodes[0], False)
+    check_shared("after node selection")
+
+    tracks_viewer.set_display_mode("lineage")
+    check_shared("after switching to lineage mode")
+
+    seg_layer.contour = 1
+    check_shared("after enabling contours")
+
+    new_label(seg_layer)  # adds a label, so a new entry in the color dict
+    check_shared("after a new label")
+
+    # Rendering the main viewer in 3D with contours on is the one case where the copies
+    # need their own colormap: contours are not rendered in 3D, so the original hides its
+    # background labels while the (2D) copies must keep showing them.
+    viewer.dims.ndisplay = 3
+    tracks_viewer.selected_nodes.add(nodes[1], False)
+    background_label = next(
+        label for label in seg_layer.background if label not in (None, 0)
+    )
+    for copied_layer in copies:
+        assert copied_layer.colormap is not seg_layer.colormap
+        assert seg_layer.colormap.color_dict[background_label][3] == 0
+        assert (
+            copied_layer.colormap.color_dict[background_label][3]
+            == seg_layer.background_opacity
+        )
+        # the colors themselves must still match
+        for label, color in seg_layer.colormap.color_dict.items():
+            assert np.allclose(copied_layer.colormap.color_dict[label][:3], color[:3])
+
+    # and back to sharing once the main viewer is 2D again
+    viewer.dims.ndisplay = 2
+    tracks_viewer.selected_nodes.add(nodes[0], False)
+    check_shared("back in 2D")
+
+    m.cleanup()
 
 
 def test_hook_connections_released_on_hide(

--- a/tests/data_views/test_ortho_views.py
+++ b/tests/data_views/test_ortho_views.py
@@ -3,9 +3,10 @@ import math
 
 import numpy as np
 import pytest
-from napari.layers import Labels, Points
 from napari_orthogonal_views.ortho_view_widget import OrthoViewWidget
 
+from motile_tracker.data_views.views.layers.contour_labels import ContourLabels
+from motile_tracker.data_views.views.layers.out_of_slice_points import ZOnlyPoints
 from motile_tracker.data_views.views.layers.track_labels import (
     TrackLabels,
     new_label,
@@ -50,10 +51,14 @@ def test_ortho_views(viewer, qtbot, solution_tracks_3d_with_division):
     m.show()
     qtbot.waitUntil(lambda: m.is_shown(), timeout=1000)
     assert isinstance(m.right_widget, OrthoViewWidget)
-    assert isinstance(m.right_widget.vm_container.viewer_model.layers[-1], Labels)
-    assert isinstance(m.bottom_widget.vm_container.viewer_model.layers[-1], Labels)
-    assert isinstance(m.right_widget.vm_container.viewer_model.layers[-2], Points)
-    assert isinstance(m.bottom_widget.vm_container.viewer_model.layers[-2], Points)
+    assert isinstance(
+        m.right_widget.vm_container.viewer_model.layers[-1], ContourLabels
+    )
+    assert isinstance(
+        m.bottom_widget.vm_container.viewer_model.layers[-1], ContourLabels
+    )
+    assert isinstance(m.right_widget.vm_container.viewer_model.layers[-2], ZOnlyPoints)
+    assert isinstance(m.bottom_widget.vm_container.viewer_model.layers[-2], ZOnlyPoints)
     assert (
         m.right_widget.vm_container.viewer_model.layers[-1].contour
         == viewer.layers[-1].contour

--- a/tests/data_views/test_ortho_views.py
+++ b/tests/data_views/test_ortho_views.py
@@ -104,3 +104,49 @@ def test_ortho_views(viewer, qtbot, solution_tracks_3d_with_division):
     )
 
     m.cleanup()
+
+
+def n_slots(signal):
+    """Number of callbacks on a napari EventEmitter or a psygnal SignalInstance."""
+
+    callbacks = getattr(signal, "callbacks", None)
+    return len(callbacks) if callbacks is not None else len(signal)
+
+
+def test_hook_connections_released_on_hide(
+    viewer, qtbot, solution_tracks_3d_with_division
+):
+    """The hooks connect to the *original* layers but close over the copied layers, so
+    hiding the orthogonal views has to disconnect them again.
+
+    If they survive, every hide/show cycle adds another handler that rebuilds the
+    colormap of / re-slices a copied layer nobody sees anymore, which makes every
+    selection and every paint permanently slower.
+    """
+
+    m = initialize_ortho_views(viewer)
+    tracks_viewer = TracksViewer.get_instance(viewer)
+    tracks_viewer.update_tracks(tracks=solution_tracks_3d_with_division, name="test")
+
+    seg_layer = tracks_viewer.tracking_layers.seg_layer
+    points_layer = tracks_viewer.tracking_layers.points_layer
+
+    def hook_slot_counts():
+        return (
+            n_slots(seg_layer.events.colormap),  # colormap_hook
+            n_slots(points_layer.events.border_color),  # point_data_hook
+            n_slots(points_layer.data_updated),  # point_data_hook
+            n_slots(seg_layer.events.paint),  # paint_event_hook + container
+        )
+
+    baseline = hook_slot_counts()
+
+    for _ in range(3):
+        m.show()
+        qtbot.waitUntil(lambda: m.is_shown(), timeout=1000)
+        assert hook_slot_counts() > baseline  # connected while shown
+
+        m.hide()
+        assert hook_slot_counts() == baseline  # and released again
+
+    m.cleanup()

--- a/tests/data_views/test_ortho_views.py
+++ b/tests/data_views/test_ortho_views.py
@@ -1,3 +1,6 @@
+import collections
+import math
+
 import numpy as np
 import pytest
 from napari.layers import Labels, Points
@@ -192,6 +195,59 @@ def test_colormap_shared_with_ortho_views(
     viewer.dims.ndisplay = 2
     tracks_viewer.selected_nodes.add(nodes[0], False)
     check_shared("back in 2D")
+
+    m.cleanup()
+
+
+def test_point_outline_updates_ortho_views_once(
+    viewer, qtbot, solution_tracks_3d_with_division
+):
+    """Updating the point outline must emit a single border color event.
+
+    The orthogonal views re-slice their copy of the points layer whenever the border
+    color changes (napari's size setter is silent, which is why the views listen to the
+    border color), so emitting the same state twice doubles that work per view.
+    """
+
+    m = initialize_ortho_views(viewer)
+    tracks_viewer = TracksViewer.get_instance(viewer)
+    tracks_viewer.update_tracks(tracks=solution_tracks_3d_with_division, name="test")
+    m.show()
+    qtbot.waitUntil(lambda: m.is_shown(), timeout=1000)
+
+    points_layer = tracks_viewer.tracking_layers.points_layer
+    copies = [
+        widget.vm_container.viewer_model.layers[points_layer.name]
+        for widget in (m.right_widget, m.bottom_widget)
+    ]
+
+    emitted = collections.Counter()
+    points_layer.events.border_color.connect(
+        lambda event: emitted.update(["border_color"])
+    )
+
+    node = tracks_viewer.tracks.graph.node_ids()[1]
+    tracks_viewer.selected_nodes.add(node, False)
+    assert emitted["border_color"] == 1, emitted
+
+    # the selected point is highlighted and enlarged, and the copies follow
+    index = points_layer.node_index_dict[node]
+    assert np.allclose(points_layer.border_color[index], (0, 1, 1, 1))
+    assert points_layer.size[index] == math.ceil(1.3 * points_layer.default_size)
+    for copied_layer in copies:
+        assert np.array_equal(copied_layer.size, points_layer.size)
+        assert np.array_equal(copied_layer.shown, points_layer.shown)
+
+    # hiding all but one node must reach the copies as well
+    points_layer.update_point_outline([int(node)])
+    assert points_layer.shown.sum() == 1
+    for copied_layer in copies:
+        assert np.array_equal(copied_layer.shown, points_layer.shown)
+
+    points_layer.update_point_outline("all")
+    assert points_layer.shown.all()
+    for copied_layer in copies:
+        assert np.array_equal(copied_layer.shown, points_layer.shown)
 
     m.cleanup()
 


### PR DESCRIPTION
The current ortho view integration in motile-tracker is slow. Claude and I had a long discussion about the sources of the slowness, and we could fix some but it also required several new changes in napari-orthogonal-views (https://github.com/AnniekStok/napari-orthogonal-views/pull/21), to make it easier for other plugins to inject their custom behavior in the orthoview widgets. 

Claude report:

## Performance

- Hook connections leaked on every hide/show. The hooks connect to the original layers but close over the copies, so hiding the views left them attached: +2 colormap handlers, +2 border-colour handlers, +2 data_updated handlers per cycle, each servicing an invisible layer. Plus the undo/redo monkeypatching, which chained a wrapper deeper each time, and an untracked axes.events.visible connection. Hooks now report what they connected, and the container releases it.
- The colormap was rebuilt from scratch per view per event. DirectLabelColormap(...) re-validates every colour through pydantic — 2.75 s of a 5 s selection profile. The copies now share the original's colormap object, and only build their own in the one case where they must (3D + contours, where background opacity differs).
- Doubled events on the points path. update_point_outline assigned border_color/size twice each, and sync_shown_points re-sliced three times per call. Actual re-slices on the copies per action: 12 → 2 for selection and display-mode, 36 → 12 for a paint.
- Labels data re-assigned when the array was already shared. _update_data now refreshes and emits the data event instead of re-running the dims/extent bookkeeping.
- Wasted syncing. sync_filters never reached nested properties, so TrackGraph — declared "forward_exclude": "*" and not even displayed — still had 81 connections per view, now 1. Also dropped the duplicate properties/features sync, and stopped the property walk descending into TrackLabels.viewer (a whole napari Viewer offered up for bidirectional syncing).

## Correctness fixes

- Crosshairs and empty ortho views at startup — four causes: the crosshair visual never positioned itself (sat at world origin), the ortho models never got an initial dims.point, they never got a reset_view so the camera stayed at origin/zoom 1, and the centre-sync's initial alignment wrote the main viewer's depth component (always 0 in 2D) into the ortho view's own axis. Views now open where you're looking, framed, with the crosshairs centered on the data along the displayed axes only (sliders untouched).
- initialize_ortho_views is idempotent — a second call used to duplicate every hook and crash on bind_key.
- Copied points start at the tracks' size instead of napari's default 10, with the right shown flags.

## Architecture

The plugin's built-in syncing became named hooks in one registry; Motile Tracker now registers named hooks, injects its copy_layer through set_copy_layer (the monkeypatch is gone), and narrows the built-in labels_paint to layers it doesn't manage.

## Speed improvement

Claude measured some UI actions with the ortho views active. This is the comparison of main with napari-orthogonal-views 0.3.0 with this branch and napari-orthogonal-views PR 21

overhead per action | before | after |  
-- | -- | -- | --
select node | +230 ms | +47 ms | 5× less
display-mode switch | +273 ms | +65 ms | 4× less
paint stroke | +718 ms | +319 ms | 2× less
add_tracks | +2613 ms | +1601 ms | 1.6× less

<br class="Apple-interchange-newline">

I have also tested it live on a big 3D dataset and the difference is noticeable. Painting is still too slow to work with, but we might be able to gain more on the paint event because according to Claude's analysis TrackLabels emits four colormap changes per paint and each makes both ortho view copies re-slice and rebuild their texture (~150 ms per paint on the copies). Fixing this would speed up painting without ortho views as well, probably best to fix that on a separate PR.